### PR TITLE
Explicitly denote which functions need to have their requirements injected by ngAnnotate

### DIFF
--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -7,7 +7,7 @@
  * # Select File
  * Controller for selecting a HMDA file and Reporting Year for verification.
  */
-module.exports = function ($scope, $location, FileReader, RuleEngine, HMDAEngine) {
+module.exports = /*@ngInject*/ function ($scope, $location, FileReader, RuleEngine, HMDAEngine) {
     var fiscalYears = HMDAEngine.getValidYears();
 
     // Populate the $scope

--- a/app/scripts/controllers/submit.js
+++ b/app/scripts/controllers/submit.js
@@ -7,7 +7,7 @@
  * # SubmitCtrl
  * Controller of the hmdaPilotApp
  */
-module.exports = function ($scope) {
+module.exports = /*@ngInject*/ function ($scope) {
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',

--- a/app/scripts/controllers/summaryMSA-IRS.js
+++ b/app/scripts/controllers/summaryMSA-IRS.js
@@ -7,7 +7,7 @@
  * # SummaryMSAIRSCtrl
  * Controller of the hmdaPilotApp
  */
-module.exports = function ($scope) {
+module.exports = /*@ngInject*/ function ($scope) {
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',

--- a/app/scripts/controllers/summaryQualityMacro.js
+++ b/app/scripts/controllers/summaryQualityMacro.js
@@ -7,7 +7,7 @@
  * # SummaryQualityMacroCtrl
  * Controller of the hmdaPilotApp
  */
-module.exports = function ($scope) {
+module.exports = /*@ngInject*/ function ($scope) {
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',

--- a/app/scripts/controllers/summarySyntacticalValidity.js
+++ b/app/scripts/controllers/summarySyntacticalValidity.js
@@ -7,7 +7,7 @@
  * # SummarySyntacticalValidityCtrl
  * Controller for the Syntactical and Validity Summary view
  */
-module.exports = function ($scope, $location, HMDAEngine) {
+module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine) {
 
     // Get the list of errors from the HMDAEngine
     var editErrors = HMDAEngine.getErrors();

--- a/app/scripts/directives/errorSummary.js
+++ b/app/scripts/directives/errorSummary.js
@@ -7,7 +7,7 @@
  * # Error Summary directive
  * Directive for displaying a summary of edit errors
  */
-module.exports = function () {
+module.exports = /*@ngInject*/ function () {
 
     return {
         restrict: 'E',

--- a/app/scripts/directives/fileMetadata.js
+++ b/app/scripts/directives/fileMetadata.js
@@ -7,7 +7,7 @@
  * # File Metadata directive
  * Directive for displaying metadata relevent to the current HMDA data file
  */
-module.exports = function (RuleEngine) {
+module.exports = /*@ngInject*/ function (RuleEngine) {
 
     return {
         restrict: 'E',

--- a/app/scripts/directives/fileSelector.js
+++ b/app/scripts/directives/fileSelector.js
@@ -7,7 +7,7 @@
  * # File Selector directive
  * Directive for selecting the HMDA Data file
  */
-module.exports = function () {
+module.exports = /*@ngInject*/ function () {
 
     return {
         link: function(scope, element){

--- a/app/scripts/services/fileReader.js
+++ b/app/scripts/services/fileReader.js
@@ -7,7 +7,7 @@
  * # File Reader service
  * Factory for reading a file using the File API
  */
-module.exports = function ($q) {
+module.exports = /*@ngInject*/ function ($q) {
 
     var onLoad = function(reader, deferred, scope) {
         return function () {

--- a/app/scripts/services/ruleEngine.js
+++ b/app/scripts/services/ruleEngine.js
@@ -7,7 +7,7 @@
  * # Rule Engine service
  * Service to interface with the HMDA Rule Engine
  */
-module.exports = function (HMDAEngine) {
+module.exports = /*@ngInject*/ function (HMDAEngine) {
 
     var filename;
 


### PR DESCRIPTION
This addresses the ` Error: [$injector:unpr] Unknown provider: aProvider <- a <- fileMetadataDirective` error seen in the console post-deployment. Because of the way that we are building our modules to be run through browserify, our options are to do it this way, using the strict dependency inject, or to reconfigure the build process to annotate a set of tmp files that are then browserfied.