### PR TITLE
Update the $scope in the selectFile controller if any errors are returned during the fileToJson conversion

### DIFF
--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -38,6 +38,7 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, RuleEngi
         HMDAEngine.fileToJson(hmdaData.file, hmdaData.year, function(err) {
             if (err) {
                 $scope.errors.global = err;
+                $scope.$apply();
                 return;
             }
 


### PR DESCRIPTION
This addresses an issue with #28 where if the DAT file contains a formatting issue, then the error is returned, but not displayed until the user clicked the "Start validation" button again.