### PR TITLE
Wizard nav

### DIFF
--- a/app/partials/header.html
+++ b/app/partials/header.html
@@ -12,4 +12,6 @@
     </div>
 </header>
 
+<wizard-nav steps="wizardSteps"></wizard-nav>
+
 <file-metadata></file-metadata>

--- a/app/partials/wizardNav.html
+++ b/app/partials/wizardNav.html
@@ -1,0 +1,9 @@
+<nav class="nav-wizard">
+    <ol>
+        <li ng-repeat="step in steps" class="step {{step.stepClass}}">
+            <span class="{{step.badgeClass}}">{{step.badgeText}}</span>
+            <a class="step-title" ng-if="step.isComplete()" ng-href="/#/{{step.view}}">{{step.title}}</a>
+            <span class="step-title" ng-if="!step.isComplete()">{{step.title}}</span>
+        </li>
+    </ol>
+</nav>

--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -7,8 +7,13 @@
  * # Select File
  * Controller for selecting a HMDA file and Reporting Year for verification.
  */
-module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMetadata, HMDAEngine) {
+module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMetadata, HMDAEngine, Wizard) {
     var fiscalYears = HMDAEngine.getValidYears();
+
+    // Set/Reset the state of different objects on load
+    HMDAEngine.clearHmdaJson();
+    $scope.wizardSteps = Wizard.initSteps();
+    $scope.metadata = FileMetadata.clear();
 
     // Populate the $scope
     $scope.reportingYears = fiscalYears;
@@ -47,7 +52,7 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
             HMDAEngine.runValidity(hmdaData.year);
 
             // Refresh the file metadata
-            FileMetadata.refreshFileMetadata();
+            FileMetadata.refresh();
 
             // Complete the current step in the wizard
             $scope.wizardSteps = Wizard.completeStep();

--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -12,6 +12,7 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
 
     // Set/Reset the state of different objects on load
     HMDAEngine.clearHmdaJson();
+    HMDAEngine.clearErrors();
     $scope.wizardSteps = Wizard.initSteps();
     $scope.metadata = FileMetadata.clear();
 

--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -49,6 +49,9 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
             // Refresh the file metadata
             FileMetadata.refreshFileMetadata();
 
+            // Complete the current step in the wizard
+            $scope.wizardSteps = Wizard.completeStep();
+
             // And go the summary page
             $location.path('/summarySyntacticalValidity');
             $scope.$apply(); // Force the angular to update the $scope since we're technically in a callback func

--- a/app/scripts/controllers/submit.js
+++ b/app/scripts/controllers/submit.js
@@ -7,10 +7,26 @@
  * # SubmitCtrl
  * Controller of the hmdaPilotApp
  */
-module.exports = /*@ngInject*/ function ($scope) {
-    $scope.awesomeThings = [
-      'HTML5 Boilerplate',
-      'AngularJS',
-      'Karma'
-    ];
+module.exports = /*@ngInject*/ function ($scope, $location, Wizard) {
+
+    $scope.previous = function () {
+        $location.path('/summaryMSA-IRS');
+    };
+
+    $scope.canSubmit = function() {
+        // TODO: Determine what is required to pass in order for the user to submit the form
+        return true;
+    };
+
+    // Process the form submission
+    $scope.submit = function(submissionData) {
+        // TODO: Do something with the submissionData
+        console.log('Submission Data: ', submissionData);
+
+        // Complete the current step
+        $scope.wizardSteps = Wizard.completeStep();
+
+        // Go to the next page
+        $location.path('/selectFile');
+    };
 };

--- a/app/scripts/controllers/summaryMSA-IRS.js
+++ b/app/scripts/controllers/summaryMSA-IRS.js
@@ -7,10 +7,22 @@
  * # SummaryMSAIRSCtrl
  * Controller of the hmdaPilotApp
  */
-module.exports = /*@ngInject*/ function ($scope) {
-    $scope.awesomeThings = [
-      'HTML5 Boilerplate',
-      'AngularJS',
-      'Karma'
-    ];
+module.exports = /*@ngInject*/ function ($scope, $location, Wizard) {
+
+    $scope.previous = function () {
+        $location.path('/summaryQualityMacro');
+    };
+
+    $scope.hasNext = function() {
+        // TODO: Determine what is required to pass in order for the user to go to the next page
+        return true;
+    };
+
+    $scope.next = function() {
+        // Complete the current step
+        $scope.wizardSteps = Wizard.completeStep();
+
+        // Go to the next page
+        $location.path('/submit');
+    };
 };

--- a/app/scripts/controllers/summaryQualityMacro.js
+++ b/app/scripts/controllers/summaryQualityMacro.js
@@ -7,10 +7,22 @@
  * # SummaryQualityMacroCtrl
  * Controller of the hmdaPilotApp
  */
-module.exports = /*@ngInject*/ function ($scope) {
-    $scope.awesomeThings = [
-      'HTML5 Boilerplate',
-      'AngularJS',
-      'Karma'
-    ];
+module.exports = /*@ngInject*/ function ($scope, $location, Wizard) {
+
+    $scope.previous = function () {
+        $location.path('/summarySyntacticalValidity');
+    };
+
+    $scope.hasNext = function() {
+        // TODO: Determine what is required to pass in order for the user to go to the next page
+        return true;
+    };
+
+    $scope.next = function() {
+        // Complete the current step
+        $scope.wizardSteps = Wizard.completeStep();
+
+        // Go to the next page
+        $location.path('/summaryMSA-IRS');
+    };
 };

--- a/app/scripts/controllers/summarySyntacticalValidity.js
+++ b/app/scripts/controllers/summarySyntacticalValidity.js
@@ -7,7 +7,7 @@
  * # SummarySyntacticalValidityCtrl
  * Controller for the Syntactical and Validity Summary view
  */
-module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine) {
+module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine, Wizard) {
 
     // Get the list of errors from the HMDAEngine
     var editErrors = HMDAEngine.getErrors();
@@ -15,15 +15,19 @@ module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine) {
     $scope.syntacticalErrors = editErrors.syntactical || {};
     $scope.validityErrors = editErrors.validity || {};
 
+    $scope.previous = function() {
+        $location.path('/');
+    };
+
     $scope.hasNext = function() {
         return angular.equals({}, $scope.syntacticalErrors) && angular.equals({}, $scope.validityErrors);
     };
 
     $scope.next = function() {
-        $location.path('/summaryQualityMacro');
-    };
+        // Complete the current step in the wizard
+        $scope.wizardSteps = Wizard.completeStep();
 
-    $scope.previous = function() {
-        $location.path('/');
+        // Go to the next page
+        $location.path('/summaryQualityMacro');
     };
 };

--- a/app/scripts/directives/index.js
+++ b/app/scripts/directives/index.js
@@ -7,3 +7,4 @@ var app = angular.module('hmdaPilotApp');
 app.directive('ngFileSelect', require('./fileSelector'));
 app.directive('errorSummary', require('./errorSummary'));
 app.directive('fileMetadata', require('./fileMetadata'));
+app.directive('wizardNav',    require('./wizardNav'));

--- a/app/scripts/directives/wizardNav.js
+++ b/app/scripts/directives/wizardNav.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name hmdaPilotApp.direcive:WizardNav
+ * @description
+ * # Wizard Nav directive
+ * Directive for displaying the wizard navigation.
+ */
+module.exports = /*@ngInject*/ function (StepFactory, Wizard) {
+
+    function getStepClass(step) {
+        if (step.isActive) {
+            step.stepClass = 'active';
+        } else {
+            step.stepClass = step.status;
+        }
+
+        if (step.isComplete()) {
+            step.stepClass += ' focusable';
+        }
+
+        return step;
+    }
+
+    function getStepBadge(step, stepIdx) {
+        if (step.isComplete()) {
+            step.badgeClass = 'step-badge cf-icon cf-icon-approved';
+            step.badgeText = '';
+        } else {
+            step.badgeClass = 'step-badge badge-num';
+            step.badgeText = stepIdx + 1;
+        }
+
+        return step;
+    }
+
+    return {
+        restrict: 'E',
+        templateUrl: 'partials/wizardNav.html',
+        scope: {
+            steps: '='
+        },
+        link: function(scope) {
+            // Initialize scope variables
+            scope.steps = [];
+
+            // Watch the Wizard steps to see if they change
+            scope.$watch(function() {
+                return Wizard.getCurrentStep();
+            }, function() {
+                var newSteps = Wizard.getSteps();
+
+                for (var i=0; i < newSteps.length; i++) {
+                    newSteps[i] = getStepClass(newSteps[i]);
+                    newSteps[i] = getStepBadge(newSteps[i], i);
+                }
+
+                scope.steps = newSteps;
+            });
+
+            scope.$on('$routeChangeSuccess', function (event, current, previous) {
+                if (current !== previous) {
+                    scope.steps = Wizard.getSteps();
+                }
+            });
+        }
+    };
+};

--- a/app/scripts/services/fileMetadata.js
+++ b/app/scripts/services/fileMetadata.js
@@ -13,6 +13,7 @@ module.exports = /*@ngInject*/ function (HMDAEngine) {
 
     /**
      * Relevent metadata associated with the HMDA Data file
+     *
      * @type {Object}
      */
     this.fileMetadata = fileMetadata;
@@ -27,12 +28,22 @@ module.exports = /*@ngInject*/ function (HMDAEngine) {
     };
 
     /**
+     * Reset the current file metadata
+     *
+     * @return {Object} file metadata
+     */
+    this.clear = function() {
+        fileMetadata = {};
+        return fileMetadata;
+    };
+
+    /**
      * Refresh the relevent metadata associated with the HMDA data file
      * Note: Most of the metadata is pulled in directly from the HMDA Rule Engine
      *
      * @return {Object} file metadata
      */
-    this.refreshFileMetadata = function() {
+    this.refresh = function() {
         var hmdaFileObj;
 
         hmdaFileObj = HMDAEngine.getHmdaJson();

--- a/app/scripts/services/index.js
+++ b/app/scripts/services/index.js
@@ -6,3 +6,6 @@ var app = angular.module('hmdaPilotApp');
 
 app.service('FileMetadata', require('./fileMetadata'));
 app.factory('FileReader', require('./fileReader'));
+app.constant('StepStatus',  require('./stepStatus'));
+app.factory('StepFactory',  require('./stepFactory'));
+app.service('Wizard',       require('./wizard'));

--- a/app/scripts/services/stepFactory.js
+++ b/app/scripts/services/stepFactory.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * @ngdoc factory
+ * @name hmdaPilotApp.factory:step
+ * @description
+ * # Step Factory
+ * Factory for creating steps that can be used by the Wizard navigation service.
+ */
+module.exports = /*@ngInject*/ function (StepStatus) {
+
+    // Constructor
+    function Step(title, view) {
+        this.title = title;
+        this.view = view;
+        this.status = StepStatus.incomplete;
+        this.isActive = false;
+    }
+
+    Step.prototype = {
+        isComplete: function() {
+            return this.status === StepStatus.complete;
+        },
+
+        isIncomplete: function() {
+            return this.status === StepStatus.incomplete;
+        },
+
+        markComplete: function() {
+            this.status = StepStatus.complete;
+        },
+
+        markIncomplete: function() {
+            this.status = StepStatus.incomplete;
+        }
+    };
+
+    return (Step);
+};

--- a/app/scripts/services/stepStatus.js
+++ b/app/scripts/services/stepStatus.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * @ngdoc constant
+ * @name hmdaPilotApp.constant:stepStatus
+ * @description
+ * # Step Status constant
+ * Constant definition of the different step statuses.
+ */
+module.exports = {
+    complete: 'complete',
+    incomplete: 'incomplete'
+};

--- a/app/scripts/services/wizard.js
+++ b/app/scripts/services/wizard.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * @ngdoc service
+ * @name hmdaPilotApp.service:wizard
+ * @description
+ * # Wizard navigation service
+ * Service for maintaining the state of the wizard navigation.
+ */
+module.exports = /*@ngInject*/ function (StepFactory) {
+
+    var steps,
+        currentStepIdx;
+
+    /**
+     * Initialize the steps used in the wizard
+     *
+     * @return {Array}        steps
+     */
+    this.initSteps = function() {
+        steps = [
+            new StepFactory('Select file & upload', 'selectFile'),
+            new StepFactory('Syntactical & validity edit reports', 'summarySyntacticalValidity'),
+            new StepFactory('Quality & macro edit reports', 'summaryQualityMacro'),
+            new StepFactory('MSA and IRS reports', 'summaryMSA-IRS'),
+            new StepFactory('Submit', 'submit')
+        ];
+
+        // Make the first step active
+        currentStepIdx = 0;
+        steps[currentStepIdx].isActive = true;
+
+        return steps;
+    };
+
+    /**
+     * Get a list of the steps that make up the wizard
+     *
+     * @return {Array} steps
+     */
+    this.getSteps = function() {
+        return steps;
+    };
+
+    /**
+     * Get the current step
+     *
+     * @return {Object} step
+     */
+    this.getCurrentStep = function () {
+        return steps[currentStepIdx];
+    };
+
+    /**
+     * Sets the status of the current step to Complete and makes the next step active
+     *
+     * @return {Array} steps
+     */
+    this.completeStep = function() {
+        // Mark the current step as complete
+        steps[currentStepIdx].markComplete();
+        steps[currentStepIdx].isActive = false;
+
+        if (currentStepIdx < steps.length) {
+            currentStepIdx += 1;
+            steps[currentStepIdx].isActive = true;
+        }
+
+        return steps;
+    };
+};

--- a/app/styles/hmda-pilot.less
+++ b/app/styles/hmda-pilot.less
@@ -18,6 +18,10 @@
 @import (less) "header.less";
 @import (less) "footer.less";
 
+// HMDA Pilot components
+@import (less) "utils.less";
+@import (less) "wizard.less";
+
 // Layouts
 .wrapper, .wrap {
     .grid_wrapper();
@@ -83,7 +87,7 @@ footer {
 
 // File Metadata
 .file-metadata {
-    padding: 2em 0;
+    padding: 0 0 2em 0;
 
     dt, dd {
         display: inline;

--- a/app/styles/utils.less
+++ b/app/styles/utils.less
@@ -1,0 +1,10 @@
+// Vertically align an element within its container.
+//
+// @param offset defaults to 50%
+.vertical-align(@offset:50%) {
+    position: relative;
+    top: @offset;
+    -webkit-transform: translateY(-@offset);
+    -ms-transform: translateY(-@offset);
+    transform: translateY(-@offset);
+}

--- a/app/styles/wizard.less
+++ b/app/styles/wizard.less
@@ -1,0 +1,103 @@
+// Wizard Navigation
+.nav-wizard {
+    .grid_wrapper();
+    .webfont-regular;
+    width: 100%;
+    margin-bottom: 2em;
+
+    ol {
+        list-style-type: none;
+        margin: 0; padding: 0;
+        overflow: hidden;
+        width: 100%;
+
+        .step {
+            position: relative;
+            float: left;
+            width: 17%;
+            min-height: 50px;
+            height: 50px;
+            margin-right: 1.5%;
+            margin-bottom: 0;
+            padding-bottom: 4px;
+            background-color: @gray-5;
+            border-bottom: 5px solid @darkgray;
+            list-style: none;
+
+            // Wizard states
+            &.error {
+                @a11y-color: tint(@redorange, 90%);
+
+                border-color: @redorange;
+                background-color: @a11y-color;
+
+                .step-badge {
+                    color: @a11y-color;
+                    background-color: @redorange;
+                }
+            }
+            &.complete {
+                @a11y-color: shade(@green, 27%);
+
+                border-color: @a11y-color;
+                background-color: @green-tint;
+
+                .step-badge {
+                    color: @green-tint;
+                    background-color: @a11y-color;
+                }
+            }
+            &.incomplete {
+                border-color: @darkgray;
+                background-color: @gray-5;
+
+                .step-badge {
+                    color: @gray-5;
+                    background-color: @darkgray;
+                }
+            }
+            &.active,
+            &.focusable:hover,
+            &.focusable:focus {
+                @a11y-color: tint(@teal, 8%);
+
+                border-color: @a11y-color;
+                background-color: @teal-20;
+
+                .step-badge {
+                    color: @teal-20;
+                    background-color: @a11y-color;
+                }
+            }
+
+            a { outline: 0; }
+
+            .step-title {
+                .vertical-align(55%);
+                display: block;
+                float: left;
+                width: 80%;
+                color: @black;
+            }
+
+            .step-badge {
+                .vertical-align(55%);
+                display: block;
+                float: left;
+                margin: 0 .5em;
+            }
+
+            .badge-num {
+                .webfont-demi;
+                font-size: .8em;
+                border-radius: 50%;
+                padding: .2em .55em;
+            }
+
+            .cf-icon {
+                border-radius: 50%;
+                padding: .1em .2em;
+            }
+        }
+    }
+}

--- a/app/views/submit.html
+++ b/app/views/submit.html
@@ -1,1 +1,7 @@
 <h2>Submit</h2>
+
+<form name="submission" class="form-group" ng-submit="submit(submissionData)">
+
+    <button class="btn btn__secondary" ng-click="previous()"><span class="btn_icon__left cf-icon cf-icon-left"></span> Back</button>
+    <button type="submit" class="btn" ng-disabled="!canSubmit()" ng-class="{btn__disabled: !canSubmit()}">Submit</button>
+</form>

--- a/app/views/summaryMSA-IRS.html
+++ b/app/views/summaryMSA-IRS.html
@@ -1,3 +1,6 @@
 <h2>MSA Report</h2>
 
 <h2>IRS Report</h2>
+
+<button class="btn btn__secondary" ng-click="previous()"><span class="btn_icon__left cf-icon cf-icon-left"></span> Back</button>
+<button class="btn" ng-click="next()" ng-disabled="!hasNext()" ng-class="{btn__disabled: !hasNext()}">Continue <span class="btn_icon__right cf-icon cf-icon-right"></span></button>

--- a/app/views/summaryQualityMacro.html
+++ b/app/views/summaryQualityMacro.html
@@ -1,3 +1,6 @@
 <h2>Quality Edit Report</h2>
 
 <h2>Macro Edit Report</h2>
+
+<button class="btn btn__secondary" ng-click="previous()"><span class="btn_icon__left cf-icon cf-icon-left"></span> Back</button>
+<button class="btn" ng-click="next()" ng-disabled="!hasNext()" ng-class="{btn__disabled: !hasNext()}">Continue <span class="btn_icon__right cf-icon cf-icon-right"></span></button>

--- a/app/views/summarySyntacticalValidity.html
+++ b/app/views/summarySyntacticalValidity.html
@@ -4,5 +4,5 @@
 <h2>Validity Edit Report</h2>
 <error-summary errors="validityErrors"></error-summary>
 
-<button class="btn btn__secondary" ng-click="previous()">Back</button>
-<button class="btn" ng-click="next()" ng-disabled="!hasNext()" ng-class="{btn__disabled: !hasNext()}">Continue</button>
+<button class="btn btn__secondary" ng-click="previous()"><span class="btn_icon__left cf-icon cf-icon-left"></span> Back</button>
+<button class="btn" ng-click="next()" ng-disabled="!hasNext()" ng-class="{btn__disabled: !hasNext()}">Continue <span class="btn_icon__right cf-icon cf-icon-right"></span></button>

--- a/test/spec/controllers/submit.js
+++ b/test/spec/controllers/submit.js
@@ -1,19 +1,34 @@
 'use strict';
 
-var SubmitCtrl = require('../../../app/scripts/controllers/submit');
+require('angular');
+require('angular-mocks');
 
 describe('Controller: SubmitCtrl', function () {
 
-    var ctrl,
-        scope;
+    var scope,
+        location;
 
-    // Initialize the controller and a mock scope
-    beforeEach(function () {
-        scope = {};
-        ctrl = new SubmitCtrl(scope);
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    beforeEach(inject(function ($rootScope, $location, $controller) {
+        scope = $rootScope.$new();
+        location = $location;
+
+        $controller('SubmitCtrl', {
+            $scope: scope,
+            $location: location
+        });
+    }));
+
+    describe('previous()', function() {
+        // TODO: Stubbing out for now
     });
 
-    it('should attach a list of awesomeThings to the scope', function () {
-        expect(scope.awesomeThings.length).toBe(3);
+    describe('canSubmit()', function() {
+        // TODO: Stubbing out for now
+    });
+
+    describe('submit()', function() {
+        // TODO: Stubbing out for now
     });
 });

--- a/test/spec/controllers/summaryMSA-IRS.js
+++ b/test/spec/controllers/summaryMSA-IRS.js
@@ -1,19 +1,34 @@
 'use strict';
 
-var SummaryMSAIRSCtrl = require('../../../app/scripts/controllers/summaryMSA-IRS');
+require('angular');
+require('angular-mocks');
 
 describe('Controller: SummaryMSAIRSCtrl', function () {
 
-    var ctrl,
-        scope;
+    var scope,
+        location;
 
-    // Initialize the controller and a mock scope
-    beforeEach(function () {
-        scope = {};
-        ctrl = new SummaryMSAIRSCtrl(scope);
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    beforeEach(inject(function ($rootScope, $location, $controller) {
+        scope = $rootScope.$new();
+        location = $location;
+
+        $controller('SummaryMSAIRSCtrl', {
+            $scope: scope,
+            $location: location
+        });
+    }));
+
+    describe('previous()', function() {
+        // TODO: Stubbing out for now
     });
 
-    it('should attach a list of awesomeThings to the scope', function () {
-        expect(scope.awesomeThings.length).toBe(3);
+    describe('hasNext()', function() {
+        // TODO: Stubbing out for now
+    });
+
+    describe('next()', function() {
+        // TODO: Stubbing out for now
     });
 });

--- a/test/spec/controllers/summaryQualityMacro.js
+++ b/test/spec/controllers/summaryQualityMacro.js
@@ -1,19 +1,34 @@
 'use strict';
 
-var SummaryQualityMacroCtrl = require('../../../app/scripts/controllers/summaryQualityMacro');
+require('angular');
+require('angular-mocks');
 
 describe('Controller: SummaryQualityMacroCtrl', function () {
 
-    var ctrl,
-        scope;
+    var scope,
+        location;
 
-    // Initialize the controller and a mock scope
-    beforeEach(function () {
-        scope = {};
-        ctrl = new SummaryQualityMacroCtrl(scope);
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    beforeEach(inject(function ($rootScope, $location, $controller) {
+        scope = $rootScope.$new();
+        location = $location;
+
+        $controller('SummaryQualityMacroCtrl', {
+            $scope: scope,
+            $location: location
+        });
+    }));
+
+    describe('previous()', function() {
+        // TODO: Stubbing out for now
     });
 
-    it('should attach a list of awesomeThings to the scope', function () {
-        expect(scope.awesomeThings.length).toBe(3);
+    describe('hasNext()', function() {
+        // TODO: Stubbing out for now
+    });
+
+    describe('next()', function() {
+        // TODO: Stubbing out for now
     });
 });

--- a/test/spec/controllers/summarySyntacticalValidity.js
+++ b/test/spec/controllers/summarySyntacticalValidity.js
@@ -8,6 +8,7 @@ describe('Controller: SummarySyntacticalValidityCtrl', function () {
     var scope,
         location,
         controller,
+        Wizard,
         mockEngine,
         mockErrors = {
             syntactical: {},
@@ -16,19 +17,22 @@ describe('Controller: SummarySyntacticalValidityCtrl', function () {
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
 
-    beforeEach(inject(function ($rootScope, $location, $controller) {
+    beforeEach(inject(function ($rootScope, $location, $controller, _Wizard_) {
         scope = $rootScope.$new();
         location = $location;
         controller = $controller;
+        Wizard = _Wizard_;
         mockEngine = {
             getErrors: function() {
                 return mockErrors;
             }
         };
+        Wizard.initSteps();
         $controller('SummarySyntacticalValidityCtrl', {
             $scope: scope,
             $location: location,
-            HMDAEngine: mockEngine
+            HMDAEngine: mockEngine,
+            Wizard: _Wizard_
         });
     }));
 
@@ -85,9 +89,18 @@ describe('Controller: SummarySyntacticalValidityCtrl', function () {
     });
 
     describe('next()', function() {
-        it('should direct the user to the /summaryQualityMacro page', function () {
+        beforeEach(function() {
             scope.next();
             scope.$digest();
+        });
+
+        it('should mark the current step in the wizard as complete', function () {
+            var steps = Wizard.getSteps();
+            expect(steps[0].isActive).toBeFalsy();
+            expect(steps[0].status).toBe('complete');
+        });
+
+        it('should direct the user to the /summaryQualityMacro page', function () {
             expect(location.path()).toBe('/summaryQualityMacro');
         });
     });

--- a/test/spec/directives/wizardNav.js
+++ b/test/spec/directives/wizardNav.js
@@ -1,0 +1,69 @@
+/*global jQuery:true*/
+
+'use strict';
+
+require('angular');
+require('angular-mocks');
+
+describe('Directive: WizardNav', function () {
+
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    var element,
+        scope,
+        StepFactory,
+        Wizard;
+
+    beforeEach(inject(function ($templateCache) {
+        var templateUrl = 'partials/wizardNav.html';
+        var asynchronous = false;
+
+        var req = new XMLHttpRequest();
+        req.onload = function () {
+            $templateCache.put(templateUrl, this.responseText);
+        };
+        req.open('get', '/base/app/' + templateUrl, asynchronous);
+        req.send();
+    }));
+
+    beforeEach(inject(function ($rootScope, $compile, _StepFactory_, _Wizard_) {
+        StepFactory = _StepFactory_;
+        Wizard = _Wizard_;
+
+        scope = $rootScope.$new();
+
+        var stepData = [
+            new StepFactory('Step 1', 'step1'),
+            new StepFactory('Step 2', 'step2'),
+            new StepFactory('Step 3', 'step3')
+        ];
+        Wizard.initSteps(stepData);
+        Wizard.completeStep();
+
+        scope.steps = stepData;
+        var html = '<wizard-nav steps="steps"></wizard-nav>';
+        element = $compile(html)(scope);
+        scope.$digest();
+    }));
+
+    it('should display a link for the currently active step ', function () {
+        expect(jQuery('li.active > a.title', element)).toBeDefined();
+    });
+
+    it('should not display a link for incomplete steps', function () {
+        expect(jQuery('li.incomplete > span.title', element)).toBeDefined();
+    });
+
+    it('should display a number badge for an incomplete step', function () {
+        expect(jQuery('li.incomplete > span.step-badge', element).hasClass('badge-num')).toBeTruthy();
+        expect(jQuery('li.incomplete > span.step-badge', element).eq(0).text()).toBe('3');
+    });
+
+    it('should display an approved badge for a completed step', function () {
+        expect(jQuery('li.complete > span.step-badge', element).hasClass('cf-icon-approved')).toBeTruthy();
+    });
+
+    it('should allow a completed step to be focusable', function () {
+        expect(jQuery('li.complete', element).hasClass('focusable')).toBeTruthy();
+    });
+});

--- a/test/spec/services/fileMetadata.js
+++ b/test/spec/services/fileMetadata.js
@@ -24,12 +24,12 @@ describe('Service: FileMetadata', function () {
         HMDAEngine = _HMDAEngine_;
     }));
 
-    describe('getFileMetadata', function (){
+    describe('refresh()', function (){
         describe('when the rule-engine has processed the file', function() {
             beforeEach(function() {
                 HMDAEngine.setHmdaJson(mockHmdaFile);
                 service.setFilename('test.dat');
-                service.refreshFileMetadata();
+                service.refresh();
             });
 
             it('should return a metadata object', function (){
@@ -44,13 +44,22 @@ describe('Service: FileMetadata', function () {
         describe('when the rule-engine has not processed the file', function() {
             beforeEach(function() {
                 HMDAEngine.setHmdaJson({});
-                service.refreshFileMetadata();
             });
 
             it('should return an empty object', function (){
-                var metadata = service.fileMetadata;
-                expect(metadata).toEqual({});
+                expect(service.refresh()).toEqual({});
             });
+        });
+    });
+
+    describe('clear()', function() {
+        beforeEach(function() {
+            HMDAEngine.setHmdaJson(mockHmdaFile);
+            service.setFilename('test.dat');
+        });
+
+        it('should return an empty object', function (){
+            expect(service.clear()).toEqual({});
         });
     });
 });

--- a/test/spec/services/stepFactory.js
+++ b/test/spec/services/stepFactory.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var StepStatus = require('../../../app/scripts/services/stepStatus');
+var StepFactory = require('../../../app/scripts/services/stepFactory')(StepStatus);
+
+describe('Factory: StepFactory', function () {
+
+    var step;
+
+    // Initialize the factory
+    beforeEach(function () {
+        step = new StepFactory('title2', 'view');
+    });
+
+    it('should default the status to incomplete', function () {
+        expect(step.status).toBe('incomplete');
+    });
+
+    it('should default isActive to false', function () {
+        expect(step.isActive).toBeFalsy();
+    });
+
+    describe('isComplete', function() {
+        it('should be false by default', function () {
+            expect(step.isComplete()).toBeFalsy();
+        });
+    });
+
+    describe('isIncomplete', function() {
+        it('should be true by default', function () {
+            expect(step.isIncomplete()).toBeTruthy();
+        });
+    });
+
+    describe('markComplete', function() {
+        it('should set the step status to complete', function () {
+            step.markComplete();
+            expect(step.isComplete()).toBeTruthy();
+        });
+    });
+
+    describe('markIncomplete', function() {
+        it('should set the step status to incomplete', function () {
+            step.markIncomplete();
+            expect(step.isIncomplete()).toBeTruthy();
+        });
+    });
+});

--- a/test/spec/services/wizard.js
+++ b/test/spec/services/wizard.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('angular');
+require('angular-mocks');
+
+describe('Service: Wizard', function () {
+
+    var service,
+        steps,
+        StepStatus;
+
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    beforeEach(inject(function (_Wizard_, _StepStatus_) {
+        service = _Wizard_;
+        StepStatus = _StepStatus_;
+
+        steps = service.initSteps();
+    }));
+
+    describe('initSteps', function() {
+
+        it('should set the first step to active', function () {
+            expect(steps[0].isActive).toBeTruthy();
+        });
+    });
+
+    describe('getSteps', function() {
+
+        beforeEach(function() {
+            steps = service.getSteps();
+        });
+
+        it('should return the steps', function () {
+            expect(steps[0].status).toBe(StepStatus.incomplete);
+            expect(steps[0].isActive).toBeTruthy();
+            expect(steps[1].status).toBe(StepStatus.incomplete);
+            expect(steps[2].status).toBe(StepStatus.incomplete);
+        });
+    });
+});


### PR DESCRIPTION
For #155, we create a directive for displaying the wizard nav which is backed by a wizard service that is used to maintain the state of the wizard across the various controllers. Each step in the wizard is defined by StepFactory obj so that each step is aware of certain elements about itself.

This pr also stubs out some basic navigation for some of the other controller/views just to make it easier to test the wizard navigation. `//TODO` comments have been added to the code in order to denote where more work is required.