### PR TITLE
Fix missing file metadata

### DIFF
--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -13,8 +13,8 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
     // Set/Reset the state of different objects on load
     HMDAEngine.clearHmdaJson();
     HMDAEngine.clearErrors();
-    $scope.wizardSteps = Wizard.initSteps();
     $scope.metadata = FileMetadata.clear();
+    $scope.wizardSteps = Wizard.initSteps();
 
     // Populate the $scope
     $scope.reportingYears = fiscalYears;

--- a/app/scripts/directives/errorSummary.js
+++ b/app/scripts/directives/errorSummary.js
@@ -2,7 +2,7 @@
 
 /**
  * @ngdoc directive
- * @name hmdaPilotApp.direcive:ErrorSummary
+ * @name hmdaPilotApp.directive:ErrorSummary
  * @description
  * # Error Summary directive
  * Directive for displaying a summary of edit errors

--- a/app/scripts/directives/fileMetadata.js
+++ b/app/scripts/directives/fileMetadata.js
@@ -19,13 +19,13 @@ module.exports = /*@ngInject*/ function () {
 
             // Refresh the fileMetadata if it changes (usually only once on page load)
             $scope.$watch(function() {
-                return FileMetadata.fileMetadata;
+                return FileMetadata.get();
             }, function() {
-                angular.copy(FileMetadata.fileMetadata, $scope.metadata);
+                angular.copy(FileMetadata.get(), $scope.metadata);
 
                 // Check to see if some of the data from the parsed file is available since
                 // this information may not be immediately available like the filename
-                if (FileMetadata.fileMetadata.activityYear) {
+                if (FileMetadata.get().activityYear) {
                     $scope.showMetadata = true;
                 }
             }, true);

--- a/app/scripts/directives/fileMetadata.js
+++ b/app/scripts/directives/fileMetadata.js
@@ -12,7 +12,7 @@ module.exports = /*@ngInject*/ function () {
     return {
         restrict: 'E',
         templateUrl: 'partials/fileMetadata.html',
-        controller: function($scope, FileMetadata) {
+        controller: /*@ngInject*/ function ($scope, FileMetadata) {
             // Initialize $scope variables
             $scope.metadata = {};
             $scope.showMetadata = false;

--- a/app/scripts/directives/fileMetadata.js
+++ b/app/scripts/directives/fileMetadata.js
@@ -2,7 +2,7 @@
 
 /**
  * @ngdoc directive
- * @name hmdaPilotApp.direcive:FileMetadata
+ * @name hmdaPilotApp.directive:FileMetadata
  * @description
  * # File Metadata directive
  * Directive for displaying metadata relevent to the current HMDA data file

--- a/app/scripts/directives/fileSelector.js
+++ b/app/scripts/directives/fileSelector.js
@@ -2,7 +2,7 @@
 
 /**
  * @ngdoc directive
- * @name hmdaPilotApp.direcive:FileSelector
+ * @name hmdaPilotApp.directive:FileSelector
  * @description
  * # File Selector directive
  * Directive for selecting the HMDA Data file

--- a/app/scripts/directives/wizardNav.js
+++ b/app/scripts/directives/wizardNav.js
@@ -2,7 +2,7 @@
 
 /**
  * @ngdoc directive
- * @name hmdaPilotApp.direcive:WizardNav
+ * @name hmdaPilotApp.directive:WizardNav
  * @description
  * # Wizard Nav directive
  * Directive for displaying the wizard navigation.

--- a/app/scripts/services/fileMetadata.js
+++ b/app/scripts/services/fileMetadata.js
@@ -12,11 +12,13 @@ module.exports = /*@ngInject*/ function (HMDAEngine) {
     var fileMetadata = {};
 
     /**
-     * Relevent metadata associated with the HMDA Data file
+     * Get the metadata associated with the HMDA Data file
      *
      * @type {Object}
      */
-    this.fileMetadata = fileMetadata;
+    this.get = function() {
+        return fileMetadata;
+    };
 
     /**
      * Store the HMDA Data file's filename for the metadata

--- a/test/spec/directives/fileMetadata.js
+++ b/test/spec/directives/fileMetadata.js
@@ -18,7 +18,7 @@ describe('Directive: FileMetadata', function () {
             totalLineEntries: '42'
         },
         mockFileMetadataService = {
-            fileMetadata: mockMetadata
+            get: function() { return mockMetadata; }
         };
 
     beforeEach(function () {

--- a/test/spec/services/fileMetadata.js
+++ b/test/spec/services/fileMetadata.js
@@ -33,7 +33,7 @@ describe('Service: FileMetadata', function () {
             });
 
             it('should return a metadata object', function (){
-                var metadata = service.fileMetadata;
+                var metadata = service.get();
                 expect(metadata.filename).toBe('test.dat');
                 expect(metadata.activityYear).toBe('2015');
                 expect(metadata.respondentID).toBe('1234567890');


### PR DESCRIPTION
Add missing @ngInject annotation that's required so that we don't have to use the long-form strict-di.

Also replaced the fileMetadata property on the FileMetadata service with a get(). Had to switch this out because the property is cached by angular and must wait for some things to happen in order for its value to be refreshed. In some cases this wasn't happening fast enough for the directive to get the correct value before being displayed on the next page.