### PR TITLE
Establish a method for defining per-environment variables

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -421,16 +421,44 @@ module.exports = function (grunt) {
           dest: '<%= yeoman.app %>/bundle'
         }]
       }
-
+    },
+    replace: {
+      local: {
+        options: {
+          patterns: [{
+            json: grunt.file.readJSON('./config/environments/local.json')
+          }]
+        },
+        files: [{
+          expand: true,
+          flatten: true,
+          src: ['./config/config.js'],
+          dest: '<%= yeoman.app %>/scripts/modules/'
+        }]
+      },
+      development: {
+        options: {
+          patterns: [{
+            json: grunt.file.readJSON('./config/environments/development.json')
+          }]
+        },
+        files: [{
+          expand: true,
+          flatten: true,
+          src: ['./config/config.js'],
+          dest: '<%= yeoman.app %>/scripts/modules/'
+        }]
+      }
     }
   });
 
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-ng-annotate');
+  grunt.loadNpmTasks('grunt-replace');
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
     if (target === 'dist') {
-      return grunt.task.run(['build', 'connect:dist:keepalive']);
+      return grunt.task.run(['build:local', 'connect:dist:keepalive']);
     }
 
     grunt.task.run([
@@ -439,6 +467,7 @@ module.exports = function (grunt) {
       'less:server',
       'concurrent:server',
       'autoprefixer',
+      'replace:local',
       'connect:livereload',
       'watch'
     ]);
@@ -458,21 +487,26 @@ module.exports = function (grunt) {
     'karma'
   ]);
 
-  grunt.registerTask('build', [
-    'clean:dist',
-    'browserify:dist',
-    'ngAnnotate:dist',
-    'less:dist',
-    'useminPrepare',
-    'concurrent:dist',
-    'autoprefixer',
-    'copy:dist',
-    'cssmin',
-    'uglify',
-    'filerev',
-    'usemin',
-    'htmlmin'
-  ]);
+  grunt.registerTask('build', function (env) {
+    env = env || 'development'; // default the build env to 'development', if not specified
+
+    grunt.task.run([
+      'clean:dist',
+      'replace:' + env,
+      'browserify:dist',
+      'ngAnnotate:dist',
+      'less:dist',
+      'useminPrepare',
+      'concurrent:dist',
+      'autoprefixer',
+      'copy:dist',
+      'cssmin',
+      'uglify',
+      'filerev',
+      'usemin',
+      'htmlmin'
+    ]);
+  });
 
   grunt.registerTask('zip', [
     'compress:hmda-pilot'
@@ -485,6 +519,6 @@ module.exports = function (grunt) {
   grunt.registerTask('default', [
     'newer:jshint',
     'test',
-    'build'
+    'build:development'
   ]);
 };

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -8,6 +8,7 @@ require('angular-resource');
 require('angular-route');
 require('angular-sanitize');
 require('angular-touch');
+require('./modules/config');
 require('./modules/HMDAEngine');
 
 /**
@@ -27,6 +28,7 @@ angular
     'ngRoute',
     'ngSanitize',
     'ngTouch',
+    'services.config',
     'HMDAEngine'
   ])
   .config(function ($routeProvider) {
@@ -54,6 +56,10 @@ angular
       .otherwise({
         redirectTo: '/'
       });
+  })
+  .run(function (Configuration, HMDAEngine) {
+    // Set the location of the HMDA Engine API
+    HMDAEngine.setAPIURL(Configuration.apiUrl);
   });
 
 require('./services');

--- a/app/scripts/modules/config.js
+++ b/app/scripts/modules/config.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('services.config', [])
+    .constant('Configuration', {
+        apiUrl: 'http://localhost:8000'
+    });

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('services.config', [])
+    .constant('Configuration', {
+        apiUrl: '@@apiUrl'
+    });

--- a/config/environments/development.json
+++ b/config/environments/development.json
@@ -1,0 +1,3 @@
+{
+    "apiUrl": "http://dev.hmda-pilot.ec2.devis.com/api"
+}

--- a/config/environments/local.json
+++ b/config/environments/local.json
@@ -1,0 +1,3 @@
+{
+    "apiUrl": "http://localhost:8000"
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "grunt-karma": "^0.9.0",
     "grunt-newer": "^0.7.0",
     "grunt-ng-annotate": "^0.8.0",
+    "grunt-replace": "^0.8.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.7.0",


### PR DESCRIPTION
As part of #179, establish a method for defining per-environment variables that bundled into the project at "compile" time.

Currently only the URL for the API is being configured, but other options and additional environments can be easily added at a later date.