### PR TITLE
Add a cfButton directive that can be used for displaying a button that support a "Processing..." state

### DIFF
--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -7,7 +7,7 @@
  * # Select File
  * Controller for selecting a HMDA file and Reporting Year for verification.
  */
-module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMetadata, HMDAEngine, Wizard) {
+module.exports = /*@ngInject*/ function ($scope, $location, $timeout, FileReader, FileMetadata, HMDAEngine, Wizard) {
     var fiscalYears = HMDAEngine.getValidYears();
 
     // Set/Reset the state of different objects on load
@@ -18,6 +18,7 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
 
     // Populate the $scope
     $scope.reportingYears = fiscalYears;
+    $scope.isProcessing = false;
 
     // Initialize the errors for the form fields
     $scope.errors = {};
@@ -40,6 +41,11 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
 
     // Process the form submission
     $scope.submit = function(hmdaData) {
+        // Toggle processing flag on so that we can notify the user
+        $scope.isProcessing = true;
+
+        $timeout(function() { return; }, 250); // Pause before starting the conversion so that the DOM can update
+
         // Convert the file to JSON
         HMDAEngine.fileToJson(hmdaData.file, hmdaData.year, function(err) {
             if (err) {
@@ -57,6 +63,9 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileReader, FileMeta
 
             // Complete the current step in the wizard
             $scope.wizardSteps = Wizard.completeStep();
+
+            // Toggle processing flag off
+            $scope.isProcessing = false;
 
             // And go the summary page
             $location.path('/summarySyntacticalValidity');

--- a/app/scripts/directives/cfButton.js
+++ b/app/scripts/directives/cfButton.js
@@ -1,0 +1,114 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name hmdaPilotApp.directive:cfButton
+ * @description
+ * # Capital Framework Button directive
+ * Directive for displaying a button that use the Capital Framework
+ */
+module.exports = /*@ngInject*/ function () {
+
+    var origBtnText;
+
+    function disable($btn) {
+        $btn.prop('disabled', true);
+        $btn.addClass('btn__disabled');
+        return $btn;
+    }
+
+    function enable($btn) {
+        $btn.prop('disabled', false);
+        $btn.removeClass('btn__disabled');
+        return $btn;
+    }
+
+    function showProcessing($btn) {
+        disable($btn);
+
+        $btn.addClass('btn-processing');
+
+        var text = $btn[0].getElementsByClassName('text')[0],
+            icon = $btn[0].getElementsByClassName('cf-icon')[0],
+            iconName = icon.className.match(/(^|\s)cf-icon-\S+/g)[0] || '';
+
+        angular.element(icon)
+            .removeClass(iconName)
+            .addClass('cf-icon-update cf-spin');
+
+        angular.element(text)
+            .text('Processing...');
+
+        return $btn;
+    }
+
+    function hideProcessing($btn, iconName, btnText) {
+        enable($btn);
+
+        $btn.removeClass('btn-processing');
+
+        var text = $btn[0].getElementsByClassName('text')[0],
+            icon = $btn[0].getElementsByClassName('cf-icon')[0];
+
+        angular.element(icon)
+            .removeClass('cf-icon-update')
+            .removeClass('cf-spin')
+            .addClass('cf-icon-' + iconName);
+
+        angular.element(text)
+            .text(btnText);
+
+        return $btn;
+    }
+
+    function displayIcon($btn, name, position) {
+        position = position || 'right'; // default to placing the icon on the right
+
+        var icon = '<span class="btn_icon__' + position + '"><span class="cf-icon cf-icon-' + name + '"></span></span>';
+
+        if (position === 'right') {
+            $btn.append(icon);
+        } else {
+            $btn.prepend(icon);
+        }
+        return $btn;
+    }
+
+    function link(scope, element, attrs) {
+        origBtnText = element.text();
+
+        if (attrs.iconClass) {
+            displayIcon(element, attrs.iconClass, attrs.iconPosition);
+        }
+
+        if (scope.processing) {
+            showProcessing(element);
+        }
+    }
+
+    function controller($scope, $element, $attrs) {
+
+        // Watch to see if the value of processing changes
+        $scope.$watch('processing', function(newVal) {
+            if (newVal) {
+                showProcessing($element);
+            } else {
+                hideProcessing($element, $attrs.iconClass, origBtnText);
+            }
+        });
+    }
+
+    return {
+        restrict: 'E',
+        replace: true,
+        transclude: true,
+        template: '<button type="submit" class="btn"><span class="text" ng-transclude>{{text}}</span></button>',
+        scope: {
+            processing: '=',
+            iconClass: '=',
+            iconPosition: '='
+        },
+        link: link,
+        controller: controller
+    };
+};

--- a/app/scripts/directives/index.js
+++ b/app/scripts/directives/index.js
@@ -8,3 +8,4 @@ app.directive('ngFileSelect', require('./fileSelector'));
 app.directive('errorSummary', require('./errorSummary'));
 app.directive('fileMetadata', require('./fileMetadata'));
 app.directive('wizardNav',    require('./wizardNav'));
+app.directive('cfButton',     require('./cfButton'));

--- a/app/styles/hmda-pilot.less
+++ b/app/styles/hmda-pilot.less
@@ -34,6 +34,31 @@ footer {
     margin-top: 2em;
 }
 
+// Icons
+.cf-spin {
+  -webkit-animation: cf-spin 2s infinite linear;
+  animation: cf-spin 2s infinite linear;
+}
+@-webkit-keyframes cf-spin {
+  0% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+  100% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+}
+@keyframes cf-spin {
+  0% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+  100% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+}
 
 // Forms
 .form-well {

--- a/app/views/selectFile.html
+++ b/app/views/selectFile.html
@@ -20,6 +20,6 @@
     </div>
 
     <div class="form-buttons">
-        <button type="submit" class="btn">Start validation</button>
+        <cf-button type="submit" icon-class="right" processing="isProcessing">Start validation</cf-button>
     </div>
 </form>

--- a/test/spec/directives/cfButton.js
+++ b/test/spec/directives/cfButton.js
@@ -1,0 +1,135 @@
+/*global jQuery:true*/
+
+'use strict';
+
+require('angular');
+require('angular-mocks');
+
+describe('Directive: cfButton', function () {
+
+    var element,
+        scope;
+
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    beforeEach(inject(function ($rootScope) {
+        scope = $rootScope.$new();
+    }));
+
+    describe('by default', function() {
+        beforeEach(inject(function ($compile) {
+            element = angular.element('<cf-button>A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should be type="submit"', function() {
+            expect(element.attr('type')).toBe('submit');
+        });
+
+        it('should have the "btn" class', function() {
+            expect(element.hasClass('btn')).toBeTruthy();
+        });
+
+        it('should not have the disabled property', function() {
+            expect(element.prop('disabled')).toBeFalsy();
+        });
+
+        it('should not have the disabled class', function() {
+            expect(element.hasClass('btn__disabled')).toBeFalsy();
+        });
+
+        it('should display the button text', function() {
+            expect(jQuery('.text', element).text()).toBe('A Button');
+        });
+
+        it('should not display "Processing..." text', function() {
+            expect(jQuery('.text', element).text()).not.toBe('Processing...');
+        });
+    });
+
+    describe('icon-class', function() {
+        beforeEach(inject(function ($compile) {
+            element = angular.element('<cf-button icon-class="test">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should display the named icon on the right by default', function() {
+            var el = jQuery('.cf-icon-test', element).parent();
+            expect(el.hasClass('btn_icon__right')).toBeTruthy();
+        });
+    });
+
+    describe('icon-position', function() {
+        beforeEach(inject(function ($compile) {
+            element = angular.element('<cf-button icon-class="test" icon-position="left">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should display the icon on the left when specified', function() {
+            var el = jQuery('.cf-icon-test', element).parent();
+            expect(el.hasClass('btn_icon__left')).toBeTruthy();
+        });
+    });
+
+    describe('if processing', function() {
+        beforeEach(inject(function ($compile) {
+            scope.isProcessing = true;
+            element = angular.element('<cf-button icon-class="test" processing="isProcessing">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should disable the button', function() {
+            expect(element.prop('disabled')).toBeTruthy();
+            expect(element.hasClass('btn__disabled')).toBeTruthy();
+        });
+
+        it('should change the button text to "Processing..."', function() {
+            var el = jQuery('span.text', element);
+            expect(el.text()).toBe('Processing...');
+            expect(element.hasClass('btn-processing')).toBeTruthy();
+        });
+
+        it('should display a spinning update icon', function() {
+            var el = jQuery('span.cf-icon', element);
+            expect(el.hasClass('cf-icon-update')).toBeTruthy();
+            expect(el.hasClass('cf-spin')).toBeTruthy();
+        });
+    });
+
+    describe('if processing turns off', function() {
+        beforeEach(inject(function ($compile) {
+            scope.isProcessing = true;
+            element = angular.element('<cf-button icon-class="test" processing="isProcessing">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+            // Make sure that the processing is being triggered
+            expect(element.prop('disabled')).toBeTruthy();
+            expect(element.hasClass('btn__disabled')).toBeTruthy();
+            // Turn off processing
+            scope.isProcessing = false;
+            scope.$digest();
+        }));
+
+        it('should enable the button', function() {
+            expect(element.prop('disabled')).toBeFalsy();
+            expect(element.hasClass('btn__disabled')).toBeFalsy();
+        });
+
+        it('should reset the button text to "A Button"', function() {
+            var el = jQuery('span.text', element);
+            expect(el.text()).toBe('A Button');
+            expect(element.hasClass('btn-processing')).toBeFalsy();
+        });
+
+        it('should reset to the initial icon', function() {
+            var el = jQuery('span.cf-icon', element);
+            expect(el.hasClass('cf-icon-test')).toBeTruthy();
+            expect(el.hasClass('cf-icon-update')).toBeFalsy();
+            expect(el.hasClass('cf-spin')).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
For #178, The button uses the classes and icons defined in the Capital Framework library so that the implementer really only needs to define an initial icon to be used, the position (left or right) and then a variable in the $scope to watch for changes.