### PR TITLE
Coverage cleanup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -138,7 +138,8 @@ module.exports = function (grunt) {
           ]
         }]
       },
-      server: '.tmp'
+      server: '.tmp',
+      coverage: ['coverage/*']
     },
 
     // Add vendor prefixed styles
@@ -479,6 +480,7 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('test', [
+    'clean:coverage',
     'clean:server',
     'concurrent:test',
     'autoprefixer',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,15 @@ module.exports = function (grunt) {
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
 
+  grunt.registerTask('open_coverage', 'open coverage report in default browser', function() {
+    var exec = require('child_process').exec;
+    var cb = this.async();
+    exec('open coverage/html-report/index.html', {cwd: './'}, function(err, stdout) {
+      console.log(stdout);
+      cb();
+    });
+  });
+
   // Configurable paths for the application
   var appConfig = {
     app: 'app',
@@ -486,6 +495,11 @@ module.exports = function (grunt) {
     'autoprefixer',
     'connect:test',
     'karma'
+  ]);
+
+  grunt.registerTask('coverage', [
+    'test',
+    'open_coverage'
   ]);
 
   grunt.registerTask('build', function (env) {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -89,7 +89,8 @@ module.exports = function(config) {
     coverageReporter : {
       dir: 'coverage/',
       reporters: [
-        { type: 'html', subdir: 'html-report' }
+        { type: 'html', subdir: 'html-report' },
+        { type: 'text-summary' }
       ]
     },
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -87,8 +87,10 @@ module.exports = function(config) {
 
     // Coverage reporter configuration
     coverageReporter : {
-      type: 'html',
-      dir: 'coverage/'
+      dir: 'coverage/',
+      reporters: [
+        { type: 'html', subdir: 'html-report' }
+      ]
     },
 
     // Preproccessors


### PR DESCRIPTION
Make sure we're getting fresh coverage reports by doing a clean first. Also, print out a textual summary when running tests so it can be displayed in travis builds.