### PR TITLE
Fix the case of views/errorDetail.html

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -56,7 +56,7 @@ angular
         controller: 'SubmitCtrl'
       })
       .when('/detail/:EditType/:EditId', {
-        templateUrl: 'views/ErrorDetail.html',
+        templateUrl: 'views/errorDetail.html',
         controller: 'ErrorDetailCtrl'
       })
       .otherwise({


### PR DESCRIPTION
Fix the case of views/errorDetail.html to match the filename to fix an issue where page is served via a case-sensitive OS