### PR TITLE
Redirect the user to the home page if the HmdaJson object gets reset

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -63,9 +63,19 @@ angular
         redirectTo: '/'
       });
   })
-  .run(function (Configuration, HMDAEngine) {
+  .run(function ($rootScope, $location, Configuration, HMDAEngine) {
     // Set the location of the HMDA Engine API
     HMDAEngine.setAPIURL(Configuration.apiUrl);
+
+    // Watch the value of the HMDA JSON
+    // and redirect to the home page if it gets cleared out
+    $rootScope.$watch(function() {
+        return HMDAEngine.getHmdaJson();
+    }, function(newVal) {
+        if (angular.equals({}, newVal)) {
+            $location.path('/');
+        }
+    });
   });
 
 require('./services');


### PR DESCRIPTION
In the event the engine loses track of the HMDA file, either something catastrophic or during development the grunt forces a refresh, then we redirect the user back to the home page so that they can upload the DAT file again.