### PR TITLE
Summary and details for Quality/Macro edits

### DIFF
--- a/app/scripts/controllers/errorDetail.js
+++ b/app/scripts/controllers/errorDetail.js
@@ -29,6 +29,8 @@ module.exports = /*@ngInject*/ function ($scope, $routeParams, $location, HMDAEn
     $scope.backToSummary = function() {
         if (editType === 'syntactical' || editType === 'validity') {
             $location.path('/summarySyntacticalValidity');
+        } else if (editType === 'quality' || editType === 'macro') {
+            $location.path('/summaryQualityMacro');
         } else { // Go back to the start if nothing matches
             $location.path('/');
         }

--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -77,7 +77,6 @@ module.exports = /*@ngInject*/ function ($scope, $location, $timeout, FileReader
 
                     // And go the summary page
                     $location.path('/summarySyntacticalValidity');
-                    $scope.$apply(); // Force the angular to update the $scope since we're technically in a callback func
                 });
             });
 

--- a/app/scripts/controllers/summaryQualityMacro.js
+++ b/app/scripts/controllers/summaryQualityMacro.js
@@ -5,9 +5,15 @@
  * @name hmdaPilotApp.controller:SummaryQualityMacroCtrl
  * @description
  * # SummaryQualityMacroCtrl
- * Controller of the hmdaPilotApp
+ * Controller for the Syntactical and Validity Summary view
  */
-module.exports = /*@ngInject*/ function ($scope, $location, Wizard) {
+module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine, Wizard) {
+
+    // Get the list of errors from the HMDAEngine
+    var editErrors = HMDAEngine.getErrors();
+
+    $scope.qualityErrors = editErrors.quality || {};
+    $scope.macroErrors = editErrors.macro || {};
 
     $scope.previous = function () {
         $location.path('/summarySyntacticalValidity');

--- a/app/scripts/controllers/summarySyntacticalValidity.js
+++ b/app/scripts/controllers/summarySyntacticalValidity.js
@@ -7,7 +7,11 @@
  * # SummarySyntacticalValidityCtrl
  * Controller for the Syntactical and Validity Summary view
  */
-module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine, Wizard) {
+module.exports = /*@ngInject*/ function ($scope, $location, $timeout, HMDAEngine, Wizard) {
+
+    // Populate the $scope
+    $scope.errors = {};
+    $scope.isProcessing = false;
 
     // Get the list of errors from the HMDAEngine
     var editErrors = HMDAEngine.getErrors();
@@ -24,10 +28,36 @@ module.exports = /*@ngInject*/ function ($scope, $location, HMDAEngine, Wizard) 
     };
 
     $scope.next = function() {
-        // Complete the current step in the wizard
-        $scope.wizardSteps = Wizard.completeStep();
+        // Toggle processing flag on so that we can notify the user
+        $scope.isProcessing = true;
 
-        // Go to the next page
-        $location.path('/summaryQualityMacro');
+        $timeout(function() { return; }, 250); // Pause before starting the validation so that the DOM can update
+
+        // Run the second set of validations
+        var ruleYear = HMDAEngine.getRuleYear();
+        HMDAEngine.runQuality(ruleYear, function(qualityErr) {
+            if (qualityErr) {
+                $scope.errors.global = qualityErr;
+                $scope.$apply();
+                return;
+            }
+
+            HMDAEngine.runMacro(ruleYear, function(macroErr) {
+                if (macroErr) {
+                    $scope.errors.global = macroErr;
+                    $scope.$apply();
+                    return;
+                }
+
+                // Complete the current step in the wizard
+                $scope.wizardSteps = Wizard.completeStep();
+
+                // And go the next summary page
+                $location.path('/summaryQualityMacro');
+            });
+        });
+
+        // Toggle processing flag off
+        $scope.isProcessing = false;
     };
 };

--- a/app/scripts/directives/cfButton.js
+++ b/app/scripts/directives/cfButton.js
@@ -77,6 +77,10 @@ module.exports = /*@ngInject*/ function () {
     function link(scope, element, attrs) {
         origBtnText = element.text();
 
+        if (!attrs.ngClick) {
+            element.attr('type', 'submit');
+        }
+
         if (attrs.iconClass) {
             displayIcon(element, attrs.iconClass, attrs.iconPosition);
         }
@@ -102,7 +106,7 @@ module.exports = /*@ngInject*/ function () {
         restrict: 'E',
         replace: true,
         transclude: true,
-        template: '<button type="submit" class="btn"><span class="text" ng-transclude>{{text}}</span></button>',
+        template: '<button class="btn"><span class="text" ng-transclude>{{text}}</span></button>',
         scope: {
             processing: '=',
             iconClass: '=',

--- a/app/scripts/directives/cfButton.js
+++ b/app/scripts/directives/cfButton.js
@@ -88,18 +88,23 @@ module.exports = /*@ngInject*/ function () {
         if (scope.processing) {
             showProcessing(element);
         }
+
+        if (scope.isDisabled) {
+            disable(element);
+        }
     }
 
     function controller($scope, $element, $attrs) {
-
-        // Watch to see if the value of processing changes
-        $scope.$watch('processing', function(newVal) {
-            if (newVal) {
-                showProcessing($element);
-            } else {
-                hideProcessing($element, $attrs.iconClass, origBtnText);
-            }
-        });
+        if (!$scope.isDisabled) { // If the disabled state isn't being set 'manually'
+            // Watch to see if the value of processing changes
+            $scope.$watch('processing', function(newVal) {
+                if (newVal) {
+                    showProcessing($element);
+                } else {
+                    hideProcessing($element, $attrs.iconClass, origBtnText);
+                }
+            });
+        }
     }
 
     return {
@@ -109,6 +114,7 @@ module.exports = /*@ngInject*/ function () {
         template: '<button class="btn"><span class="text" ng-transclude>{{text}}</span></button>',
         scope: {
             processing: '=',
+            isDisabled: '=',
             iconClass: '=',
             iconPosition: '='
         },

--- a/app/views/summaryQualityMacro.html
+++ b/app/views/summaryQualityMacro.html
@@ -1,8 +1,10 @@
 <file-metadata></file-metadata>
 
 <h2>Quality Edit Report</h2>
+<error-summary type="quality" errors="qualityErrors"></error-summary>
 
 <h2>Macro Edit Report</h2>
+<error-summary type="macro" errors="macroErrors"></error-summary>
 
 <button class="btn btn__secondary" ng-click="previous()"><span class="btn_icon__left cf-icon cf-icon-left"></span> Back</button>
 <button class="btn" ng-click="next()" ng-disabled="!hasNext()" ng-class="{btn__disabled: !hasNext()}">Continue <span class="btn_icon__right cf-icon cf-icon-right"></span></button>

--- a/app/views/summarySyntacticalValidity.html
+++ b/app/views/summarySyntacticalValidity.html
@@ -7,4 +7,4 @@
 <error-summary type="validity" errors="validityErrors"></error-summary>
 
 <button class="btn btn__secondary" ng-click="previous()"><span class="btn_icon__left cf-icon cf-icon-left"></span> Back</button>
-<button class="btn" ng-click="next()" ng-disabled="!hasNext()" ng-class="{btn__disabled: !hasNext()}">Continue <span class="btn_icon__right cf-icon cf-icon-right"></span></button>
+<cf-button icon-class="right" is-disabled="!hasNext()" ng-click="next()" processing="isProcessing">Continue</cf-button>

--- a/test/spec/controllers/errorDetail.js
+++ b/test/spec/controllers/errorDetail.js
@@ -96,6 +96,40 @@ describe('Controller: ErrorDetailCtrl', function () {
             });
         });
 
+        describe('when editType is "quality"', function() {
+            it('should direct the user to the summaryQualityMacro page', function() {
+                controller('ErrorDetailCtrl', {
+                    $scope: scope,
+                    $routeParams: {
+                        EditType: 'quality',
+                        EditId: 'S999'
+                    },
+                    HMDAEngine: HMDAEngine
+                });
+
+                scope.backToSummary();
+                scope.$digest();
+                expect(location.path()).toBe('/summaryQualityMacro');
+            });
+        });
+
+        describe('when editType is "macro"', function() {
+            it('should direct the user to the summaryQualityMacro page', function() {
+                controller('ErrorDetailCtrl', {
+                    $scope: scope,
+                    $routeParams: {
+                        EditType: 'macro',
+                        EditId: 'S999'
+                    },
+                    HMDAEngine: HMDAEngine
+                });
+
+                scope.backToSummary();
+                scope.$digest();
+                expect(location.path()).toBe('/summaryQualityMacro');
+            });
+        });
+
         describe('when editType doesn\'t match a known type', function() {
             it('should direct the user to the home(/) page', function() {
                 controller('ErrorDetailCtrl', {

--- a/test/spec/controllers/selectFile.js
+++ b/test/spec/controllers/selectFile.js
@@ -5,27 +5,41 @@ require('angular-mocks');
 
 describe('Controller: SelectFileCtrl', function () {
 
-    var scope,
+    var controller,
+        scope,
         location,
+        Wizard,
         FileMetadata,
         FileReader,
-        HMDAEngine;
+        HMDAEngine,
+        mockEngine = {
+            getValidYears: function() { return ['2013', '2014']; },
+            clearHmdaJson: function () { return {}; },
+            clearErrors: function () { return {}; },
+            fileToJson: function(file, year, next) { return next(null); },
+            runSyntactical: function(year, next) { return next(null); },
+            runValidity: function(year, next) { return next(null); }
+        };
+
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
 
-    beforeEach(inject(function ($rootScope, $location, $controller, _FileMetadata_, _FileReader_, _HMDAEngine_) {
+    beforeEach(inject(function ($rootScope, $location, $controller, _Wizard_, _FileMetadata_, _FileReader_) {
         scope = $rootScope.$new();
+        controller = $controller;
         location = $location;
+        Wizard = _Wizard_;
         FileMetadata = _FileMetadata_;
         FileReader = _FileReader_;
-        HMDAEngine = _HMDAEngine_;
+        HMDAEngine = mockEngine;
 
-        $controller('SelectFileCtrl', {
+        controller('SelectFileCtrl', {
             $scope: scope,
             $location: location,
+            Wizard: _Wizard_,
             FileMetadata: _FileMetadata_,
             FileReader: _FileReader_,
-            HMDAEngine: _HMDAEngine_
+            HMDAEngine: mockEngine
         });
     }));
 
@@ -49,10 +63,100 @@ describe('Controller: SelectFileCtrl', function () {
     });
 
     describe('getFile()', function() {
+        beforeEach(function() {
+            scope.file = {
+                name: 'test.dat'
+            };
+            scope.getFile();
+            scope.$digest();
+        });
 
+        it('should set the filemane value in the in the scope', function () {
+            var metadata = FileMetadata.get();
+            expect(metadata.filename).toBe('test.dat');
+        });
     });
 
     describe('submit()', function() {
-        // Nothing really to test yet...
+
+        var hmdaData = {
+            file: 'test.dat',
+            year: '2013'
+        };
+
+        describe('when fileToJson has a runtime error', function() {
+            it('should display a global error', function() {
+                mockEngine.fileToJson = function(file, year, next) { return next('error'); };
+                mockEngine.runSyntactical = function(year, next) { return next(null); };
+                mockEngine.runValidity = function(year, next) { return next(null); };
+                controller('SelectFileCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    HMDAEngine: mockEngine
+                });
+                scope.submit(hmdaData);
+                scope.$digest();
+
+                expect(scope.errors.global).toBe('error');
+            });
+        });
+
+        describe('when runSyntactical has a runtime error', function() {
+            it('should display a global error', function() {
+                mockEngine.fileToJson = function(file, year, next) { return next(null); };
+                mockEngine.runSyntactical = function(year, next) { return next('error'); };
+                mockEngine.runValidity = function(year, next) { return next(null); };
+                controller('SelectFileCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    HMDAEngine: mockEngine
+                });
+                scope.submit(hmdaData);
+                scope.$digest();
+
+                expect(scope.errors.global).toBe('error');
+            });
+        });
+
+        describe('when runValidity has a runtime error', function() {
+            it('should display a global error', function() {
+                mockEngine.fileToJson = function(file, year, next) { return next(null); };
+                mockEngine.runSyntactical = function(year, next) { return next(null); };
+                mockEngine.runValidity = function(year, next) { return next('error'); };
+                controller('SelectFileCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    HMDAEngine: mockEngine
+                });
+                scope.submit(hmdaData);
+                scope.$digest();
+
+                expect(scope.errors.global).toBe('error');
+            });
+        });
+
+        describe('when runSyntactical and runValidity have no runtime errors', function() {
+            beforeEach(function() {
+                mockEngine.runSyntactical = function(year, next) { return next(null); };
+                mockEngine.runValidity = function(year, next) { return next(null); };
+                controller('SelectFileCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    HMDAEngine: mockEngine
+                });
+                scope.submit(hmdaData);
+                scope.$digest();
+            });
+
+            it('should mark the current step in the wizard as complete', function () {
+                var steps = Wizard.getSteps();
+                expect(steps[0].isActive).toBeFalsy();
+                expect(steps[0].status).toBe('complete');
+            });
+
+            it('should direct the user to the /summarySyntacticalValidity page', function () {
+                expect(location.path()).toBe('/summarySyntacticalValidity');
+            });
+        });
     });
 });

--- a/test/spec/controllers/summaryQualityMacro.js
+++ b/test/spec/controllers/summaryQualityMacro.js
@@ -6,22 +6,45 @@ require('angular-mocks');
 describe('Controller: SummaryQualityMacroCtrl', function () {
 
     var scope,
-        location;
+        location,
+        controller,
+        Wizard,
+        Session,
+        mockEngine,
+        mockErrors = {
+            quality: {},
+            macro: {}
+        };
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
 
-    beforeEach(inject(function ($rootScope, $location, $controller) {
+    beforeEach(inject(function ($rootScope, $location, $controller, _Wizard_, _Session_) {
         scope = $rootScope.$new();
         location = $location;
-
+        controller = $controller;
+        Wizard = _Wizard_;
+        Session = _Session_;
+        mockEngine = {
+            getErrors: function() {
+                return mockErrors;
+            }
+        };
+        Wizard.initSteps();
         $controller('SummaryQualityMacroCtrl', {
             $scope: scope,
-            $location: location
+            $location: location,
+            Session : _Session_,
+            HMDAEngine: mockEngine,
+            Wizard: _Wizard_
         });
     }));
 
-    describe('previous()', function() {
-        // TODO: Stubbing out for now
+    it('should include the quality errors in the scope', function () {
+        expect(scope.qualityErrors).toEqual({});
+    });
+
+    it('should include the macro errors in the scope', function () {
+        expect(scope.macroErrors).toEqual({});
     });
 
     describe('hasNext()', function() {
@@ -29,6 +52,30 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
     });
 
     describe('next()', function() {
-        // TODO: Stubbing out for now
+        beforeEach(function() {
+            scope.next();
+            scope.$digest();
+        });
+
+        it('should mark the current step in the wizard as complete', function () {
+            var steps = Wizard.getSteps();
+            expect(steps[0].isActive).toBeFalsy();
+            expect(steps[0].status).toBe('complete');
+        });
+
+        it('should direct the user to the /summaryMSA-IRS page', function () {
+            expect(location.path()).toBe('/summaryMSA-IRS');
+        });
+    });
+
+    describe('previous()', function () {
+        beforeEach(function() {
+            scope.previous();
+            scope.$digest();
+        });
+
+        it('should direct the user to the /summarySyntacticalValidity page', function () {
+            expect(location.path()).toBe('/summarySyntacticalValidity');
+        });
     });
 });

--- a/test/spec/controllers/summaryQualityMacro.js
+++ b/test/spec/controllers/summaryQualityMacro.js
@@ -9,7 +9,6 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
         location,
         controller,
         Wizard,
-        Session,
         mockEngine,
         mockErrors = {
             quality: {},
@@ -18,12 +17,11 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
 
-    beforeEach(inject(function ($rootScope, $location, $controller, _Wizard_, _Session_) {
+    beforeEach(inject(function ($rootScope, $location, $controller, _Wizard_) {
         scope = $rootScope.$new();
         location = $location;
         controller = $controller;
         Wizard = _Wizard_;
-        Session = _Session_;
         mockEngine = {
             getErrors: function() {
                 return mockErrors;
@@ -33,7 +31,6 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
         $controller('SummaryQualityMacroCtrl', {
             $scope: scope,
             $location: location,
-            Session : _Session_,
             HMDAEngine: mockEngine,
             Wizard: _Wizard_
         });

--- a/test/spec/directives/cfButton.js
+++ b/test/spec/directives/cfButton.js
@@ -23,7 +23,8 @@ describe('Directive: cfButton', function () {
             scope.$digest();
         }));
 
-        it('should be type="submit"', function() {
+        it('should have type="submit", if not specified', function() {
+            expect(element.attr('type')).toBeDefined();
             expect(element.attr('type')).toBe('submit');
         });
 
@@ -130,6 +131,36 @@ describe('Directive: cfButton', function () {
             expect(el.hasClass('cf-icon-test')).toBeTruthy();
             expect(el.hasClass('cf-icon-update')).toBeFalsy();
             expect(el.hasClass('cf-spin')).toBeFalsy();
+        });
+    });
+
+    describe('when the button has type="submit"', function() {
+        beforeEach(inject(function ($compile) {
+            element = angular.element('<cf-button type="submit">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should pass through type="submit"', function() {
+            expect(element.attr('type')).toBeDefined();
+            expect(element.attr('type')).toBe('submit');
+        });
+    });
+
+    describe('when the button has ngClick', function() {
+        beforeEach(inject(function ($compile) {
+            element = angular.element('<cf-button ng-click="action()">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should pass through the ngClick attr', function() {
+            expect(element.attr('ng-click')).toBeDefined();
+            expect(element.attr('ng-click')).toBe('action()');
+        });
+
+        it('should not include type="submit"', function() {
+            expect(element.attr('type')).toBeUndefined();
         });
     });
 });

--- a/test/spec/directives/cfButton.js
+++ b/test/spec/directives/cfButton.js
@@ -134,6 +134,20 @@ describe('Directive: cfButton', function () {
         });
     });
 
+    describe('when isDisabled evals to true', function() {
+        beforeEach(inject(function ($compile) {
+            scope.hasNext = function() { return true; };
+            element = angular.element('<cf-button is-disabled="hasNext()">A Button</cf-button>');
+            element = $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should disable the button', function() {
+            expect(element.prop('disabled')).toBeTruthy();
+            expect(element.hasClass('btn__disabled')).toBeTruthy();
+        });
+    });
+
     describe('when the button has type="submit"', function() {
         beforeEach(inject(function ($compile) {
             element = angular.element('<cf-button type="submit">A Button</cf-button>');


### PR DESCRIPTION
For #93, #30 and #33, update the view and controllers so that the user can only navigate to the quality/macro views if the HMDA file does not have any syntactical or validity edits.

Also, test coverage should go way up.