### PR TITLE
Mocha reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "karma-browserify": "^3.0.1",
     "karma-coverage": "0.2.6",
     "karma-jasmine": "^0.3.0",
+    "karma-mocha-reporter": "^0.3.1",
     "karma-phantomjs-launcher": "^0.1.4",
     "load-grunt-tasks": "^0.4.0",
     "napa": "^1.2.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -55,7 +55,8 @@ module.exports = function(config) {
       'karma-browserify',
       'karma-phantomjs-launcher',
       'karma-jasmine',
-      'karma-coverage'
+      'karma-coverage',
+      'karma-mocha-reporter'
     ],
 
     // Continuous Integration mode
@@ -83,7 +84,7 @@ module.exports = function(config) {
     },
 
     // Reporters
-    reporters: ['progress', 'coverage'],
+    reporters: ['mocha', 'coverage'],
 
     // Coverage reporter configuration
     coverageReporter : {


### PR DESCRIPTION
Replace the progress reporter with mocha so that we see the BDD structure of the tests. This matches the output from the other hmda* projects and may make it easier for QA to see what's already being tested with unit tests.