### PR TITLE
Update the label filter for when scope is 'hmda'

### DIFF
--- a/app/partials/errorDetail.html
+++ b/app/partials/errorDetail.html
@@ -14,8 +14,8 @@
     </thead>
     <tbody ng-repeat="item in error.errors | paginate:start():end()">
         <tr ng-repeat="(key, value) in item.properties">
-            <th class="id" scope="row" rowspan="{{item.properties | keyLength}}" ng-if="$first">{{item.loanNumber || item.lineNumber}}</th>
-            <td class="description">{{key | hmdaLabel:error.scope}}</td>
+            <td class="id" scope="row" rowspan="{{item.properties | keyLength}}" ng-if="$first">{{item.loanNumber || item.lineNumber}}</td>
+            <td class="description">{{ {'property':key, 'lineNumber':item.lineNumber} | hmdaLabel:error.scope}}</td>
             <td class="value">{{value}}</td>
             <td class="action" rowspan="{{item.properties | keyLength}}" ng-if="$first">Correct and revalidate</td>
         </tr>

--- a/app/partials/errorDetail.html
+++ b/app/partials/errorDetail.html
@@ -14,7 +14,7 @@
     </thead>
     <tbody ng-repeat="item in error.errors | paginate:start():end()">
         <tr ng-repeat="(key, value) in item.properties">
-            <td class="id" scope="row" rowspan="{{item.properties | keyLength}}" ng-if="$first">{{item.loanNumber || item.lineNumber}}</td>
+            <th class="id" scope="row" rowspan="{{item.properties | keyLength}}" ng-if="$first">{{item.loanNumber || item.lineNumber}}</th>
             <td class="description">{{ {'property':key, 'lineNumber':item.lineNumber} | hmdaLabel:error.scope}}</td>
             <td class="value">{{value}}</td>
             <td class="action" rowspan="{{item.properties | keyLength}}" ng-if="$first">Correct and revalidate</td>

--- a/app/scripts/modules/hmdaFilters.js
+++ b/app/scripts/modules/hmdaFilters.js
@@ -7,8 +7,15 @@ angular.module('hmdaFilters', [])
                 'lar': 'loanApplicationRegister',
                 'ts': 'transmittalSheet'
             };
+            // Set proper scope for properties of hmda file elements
+            if (scope === 'hmda') {
+                scope = 'lar';
+                if (input.lineNumber === '1') {
+                    scope = 'ts';
+                }
+            }
             var fileSpec = HMDAEngine.getFileSpec(FileMetadata.get().activityYear);
-            return fileSpec[scopes[scope]][input].label;
+            return fileSpec[scopes[scope]][input.property].label;
         };
     }])
     .filter('keyLength', function() {

--- a/test/spec/modules/hmdaFilters.js
+++ b/test/spec/modules/hmdaFilters.js
@@ -33,8 +33,13 @@ describe('Filters: hmdaFilters', function() {
                 get: function() { return mockMetadata; }
             },
             mockFileSpec = {
+                transmittalSheet: {
+                    activityYear: {
+                           label: 'Activity Year',
+                    }
+                },
                 loanApplicationRegister: {
-                    recordID:{
+                    recordID: {
                         element: '01',
                         label: 'Record Identifier',
                         start: '1',
@@ -54,8 +59,20 @@ describe('Filters: hmdaFilters', function() {
             });
         }));
 
-        it('should return the length of the input object\'s keys', angular.mock.inject(function(hmdaLabelFilter) {
-            expect(hmdaLabelFilter('recordID', 'lar')).toBe('Record Identifier');
+        it('should return the length of the input object\'s keys for lar', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({'property':'recordID', 'lineNumber':'2'}, 'lar')).toBe('Record Identifier');
+        }));
+
+        it('should return the length of the input object\'s keys for ts', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({'property':'activityYear', 'lineNumber':'1'}, 'ts')).toBe('Activity Year');
+        }));
+
+        it('should return the length of the input object\'s keys for hmda and line 1', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({'property':'activityYear', 'lineNumber':'1'}, 'hmda')).toBe('Activity Year');
+        }));
+
+        it('should return the length of the input object\'s keys for hmda and line != 1', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({'property':'recordID', 'lineNumber':'x'}, 'hmda')).toBe('Record Identifier');
         }));
     });
 


### PR DESCRIPTION
Noticed for edits like S025, when the scope is `hmda` that the label filter can't look up the labels from the file spec properly because the `hmda` scope doesn't exist in the implementation, nor in the file spec itself. So reset scope based on `lineNumber`.