### PR TITLE
Return property if it can't be found or label doesn't exist

### DIFF
--- a/app/scripts/modules/hmdaFilters.js
+++ b/app/scripts/modules/hmdaFilters.js
@@ -15,7 +15,11 @@ angular.module('hmdaFilters', [])
                 }
             }
             var fileSpec = HMDAEngine.getFileSpec(FileMetadata.get().activityYear);
-            return fileSpec[scopes[scope]][input.property].label;
+            var property = fileSpec[scopes[scope]][input.property];
+            if (property !== undefined && property.hasOwnProperty('label')) {
+                return property.label;
+            }
+            return input.property;
         };
     }])
     .filter('keyLength', function() {

--- a/test/spec/modules/hmdaFilters.js
+++ b/test/spec/modules/hmdaFilters.js
@@ -74,6 +74,14 @@ describe('Filters: hmdaFilters', function() {
         it('should return the length of the input object\'s keys for hmda and line != 1', angular.mock.inject(function(hmdaLabelFilter) {
             expect(hmdaLabelFilter({'property':'recordID', 'lineNumber':'x'}, 'hmda')).toBe('Record Identifier');
         }));
+
+        it('should return the property as label when property can\'t be found and line 1', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({'property':'Foo Bar', 'lineNumber':'1'}, 'hmda')).toBe('Foo Bar');
+        }));
+
+        it('should return the property as label when property can\'t be found and line != 1', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({'property':'Bar Foo', 'lineNumber':'x'}, 'hmda')).toBe('Bar Foo');
+        }));
     });
 
     describe('capitalize', function() {


### PR DESCRIPTION
Some of the quality edits are going to work against the whole HMDA file, and won't have properties to look up, e.g. Q130, so this solves the issue by allowing us to just pass through the actual property if it can't find the property in the filespec or label doesn't exist.