### PR TITLE
Dont rerun edits if error data already exists

### DIFF
--- a/app/data/macro-comments.json
+++ b/app/data/macro-comments.json
@@ -7,7 +7,7 @@
         "Large number of denied pre-approvals and applications this year"
     ],
     "Q007": [
-        "Applicants withdraw a large percentage of loans",
+        "Applicants withdrew a large percentage of loans",
         "Applicants decided to not move forward with the loan process",
         "Large number of customers applied but had few loan closures",
         "Purchased a lot of loans this year instead of originating them",
@@ -25,7 +25,7 @@
     ],
     "Q010": [
         "Large number of customers applied but did not close their loans",
-        "Applicants withdraw a large percentage of loans",
+        "Applicants withdrew a large percentage of loans",
         "Large percentage of the few loan applications did not qualify for loan terms",
         "Purchased a lot of loans this year instead of originating them"
     ],

--- a/app/scripts/controllers/summaryQualityMacro.js
+++ b/app/scripts/controllers/summaryQualityMacro.js
@@ -27,6 +27,10 @@ module.exports = /*@ngInject*/ function ($scope, $location, $q, $timeout, HMDAEn
         return diff.length > 0;
     }
 
+    function hasErrors(obj) {
+        return Object.keys(obj).length > 0;
+    }
+
     // Populate the $scope
     $scope.errors = {};
     $scope.isProcessing = false;
@@ -46,10 +50,15 @@ module.exports = /*@ngInject*/ function ($scope, $location, $q, $timeout, HMDAEn
     };
 
     $scope.next = function() {
-        // Toggle processing flag on so that we can notify the user
-        $scope.isProcessing = true;
+        if (hasErrors(editErrors.special)) {
+            $location.path('/summaryMSA-IRS');
+        } else {
+            // Toggle processing flag on so that we can notify the user
+            $scope.isProcessing = true;
 
-        $timeout(function() { $scope.process(); }, 100); // Pause before starting the validation so that the DOM can update
+            // Pause before starting the validation so that the DOM can update
+            $timeout(function() { $scope.process(); }, 100);
+        }
     };
 
     $scope.process = function() {

--- a/app/scripts/controllers/summarySyntacticalValidity.js
+++ b/app/scripts/controllers/summarySyntacticalValidity.js
@@ -27,11 +27,20 @@ module.exports = /*@ngInject*/ function ($scope, $location, $q, $timeout, HMDAEn
         return angular.equals({}, $scope.syntacticalErrors) && angular.equals({}, $scope.validityErrors);
     };
 
-    $scope.next = function() {
-        // Toggle processing flag on so that we can notify the user
-        $scope.isProcessing = true;
+    function hasErrors(obj) {
+        return Object.keys(obj).length > 0;
+    }
 
-        $timeout(function() { $scope.process(); }, 100); // Pause before starting the validation so that the DOM can update
+    $scope.next = function() {
+        if (hasErrors(editErrors.quality) || hasErrors(editErrors.macro)) {
+            $location.path('/summaryQualityMacro');
+        } else{
+            // Toggle processing flag on so that we can notify the user
+            $scope.isProcessing = true;
+
+            // Pause before starting the validation so that the DOM can update
+            $timeout(function() { $scope.process(); }, 100);
+        }
     };
 
     $scope.process = function() {

--- a/app/views/specialErrorDetail.html
+++ b/app/views/specialErrorDetail.html
@@ -2,7 +2,7 @@
 
 <p class="edit-explanation">{{editError.explanation}}</p>
 
-<form novalidate class="form-verify form-well" ng-submit="saveSpecialVerification(response)">
+<form novalidate class="form-verify" ng-submit="saveSpecialVerification(response)">
     <div ng-include="'partials/errorDetail-' + editId + '.html'"></div>
 
     <div class="form-buttons content-l">

--- a/test/spec/controllers/summaryQualityMacro.js
+++ b/test/spec/controllers/summaryQualityMacro.js
@@ -8,26 +8,29 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
     var scope,
         location,
         controller,
+        timeout,
         Q,
         Wizard,
         Session,
+        mockErrors = {
+            quality: {},
+            macro: {},
+            special: {}
+        },
         mockEngine = {
             getErrors: function() { return mockErrors; },
             getRuleYear: function() { return '2015'; },
             runSpecial: function(year, next) { return next(null); },
             getDebug: function() { return false; }
-        },
-        mockErrors = {
-            quality: {},
-            macro: {}
         };
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
 
-    beforeEach(inject(function ($rootScope, $location, $controller, $q, _Wizard_, _Session_) {
+    beforeEach(inject(function ($rootScope, $location, $controller, $q, $timeout, _Wizard_, _Session_) {
         scope = $rootScope.$new();
         location = $location;
         controller = $controller;
+        timeout = $timeout;
         Q = $q;
         Wizard = _Wizard_;
         Session = _Session_;
@@ -35,6 +38,7 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
         $controller('SummaryQualityMacroCtrl', {
             $scope: scope,
             $location: location,
+            $timeout: timeout,
             HMDAEngine: mockEngine,
             Wizard: _Wizard_,
             Session: _Session_
@@ -91,6 +95,54 @@ describe('Controller: SummaryQualityMacroCtrl', function () {
                 });
 
                 expect(scope.hasNext()).toBeFalsy();
+            });
+        });
+    });
+
+    describe('next()', function() {
+        describe('when special edit checks have already been run', function() {
+            beforeEach(function() {
+                mockErrors.special = {Q029: 'test'};
+                controller('SummaryQualityMacroCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    HMDAEngine: mockEngine,
+                    Session: Session
+                });
+            });
+
+            it('should not re-run the process() function', function() {
+                spyOn(scope, 'process');
+                scope.next();
+                scope.$digest();
+                expect(scope.process).not.toHaveBeenCalled();
+            });
+
+            it('should direct the user to the /summaryMSA-IRS page', function () {
+                scope.next();
+                scope.$digest();
+                expect(location.path()).toBe('/summaryMSA-IRS');
+            });
+        });
+
+        describe('when special edit checks have not been run', function() {
+            beforeEach(function() {
+                mockErrors.special = {};
+                controller('SummaryQualityMacroCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    $timeout: timeout,
+                    HMDAEngine: mockEngine,
+                    Session: Session
+                });
+            });
+
+            it('should run the process() function', function() {
+                spyOn(scope, 'process');
+                scope.next();
+                scope.$digest();
+                timeout.flush();
+                expect(scope.process).toHaveBeenCalled();
             });
         });
     });

--- a/test/spec/controllers/summarySyntacticalValidity.js
+++ b/test/spec/controllers/summarySyntacticalValidity.js
@@ -8,11 +8,14 @@ describe('Controller: SummarySyntacticalValidityCtrl', function () {
     var scope,
         location,
         controller,
+        timeout,
         Q,
         Wizard,
         mockErrors = {
             syntactical: {},
-            validity: {}
+            validity: {},
+            quality: {},
+            macro: {}
         },
         mockEngine = {
             getErrors: function() { return mockErrors; },
@@ -24,16 +27,18 @@ describe('Controller: SummarySyntacticalValidityCtrl', function () {
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
 
-    beforeEach(inject(function ($rootScope, $location, $controller, $q, _Wizard_) {
+    beforeEach(inject(function ($rootScope, $location, $controller, $q, $timeout, _Wizard_) {
         scope = $rootScope.$new();
         location = $location;
         controller = $controller;
+        timeout = $timeout;
         Q = $q;
         Wizard = _Wizard_;
         Wizard.initSteps();
         $controller('SummarySyntacticalValidityCtrl', {
             $scope: scope,
             $location: location,
+            $timeout: timeout,
             HMDAEngine: mockEngine,
             Wizard: _Wizard_
         });
@@ -87,6 +92,53 @@ describe('Controller: SummarySyntacticalValidityCtrl', function () {
                 });
 
                 expect(scope.hasNext()).toBeFalsy();
+            });
+        });
+    });
+
+    describe('next()', function() {
+        describe('when quality or macro edit checks have already been run', function() {
+            beforeEach(function() {
+                mockErrors.quality = {Q001: 'test'};
+                controller('SummarySyntacticalValidityCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    HMDAEngine: mockEngine
+                });
+            });
+
+            it('should not re-run the process() function', function() {
+                spyOn(scope, 'process');
+                scope.next();
+                scope.$digest();
+                expect(scope.process).not.toHaveBeenCalled();
+            });
+
+            it('should direct the user to the /summaryMSA-IRS page', function () {
+                scope.next();
+                scope.$digest();
+                expect(location.path()).toBe('/summaryQualityMacro');
+            });
+        });
+
+        describe('when special edit checks have not been run', function() {
+            beforeEach(function() {
+                mockErrors.quality = {};
+                mockErrors.macro = {};
+                controller('SummarySyntacticalValidityCtrl', {
+                    $scope: scope,
+                    $location: location,
+                    $timeout: timeout,
+                    HMDAEngine: mockEngine
+                });
+            });
+
+            it('should run the process() function', function() {
+                spyOn(scope, 'process');
+                scope.next();
+                scope.$digest();
+                timeout.flush();
+                expect(scope.process).toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
Fixes #261 

Of note is that we're looking for the existence of one or more errors for each validation check rather than actually tracking if the user has already triggered a specific validation. This method of tracking is slightly preferable so that we can avoid storing a tracking bit in our Session, but it does mean that if the HMDA file had 0 errors for a given validation check that it would actually re-run the validations again.

Ex. If a user has 0 quality and 0 macro errors, then clicking Continue on the Syntactical and Validation summary view would cause the validation to run again. However, this is a very unlikely scenario except with generated data files.