### PR TITLE
run grunt build:production on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 - npm install -g grunt-cli
 install: npm install
 before_deploy:
-- grunt build
+- scripts/grunt_build.bash
 - grunt zip
 - grunt codedeploy
 deploy:

--- a/scripts/grunt_build.bash
+++ b/scripts/grunt_build.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    grunt build:production
+else
+    grunt build
+fi


### PR DESCRIPTION
For #308 this runs scripts/grunt_build.bash instead of grunt directly. This new script makes a decision on what grunt commands to run based on an environment variable set by Travis.