### PR TITLE
Fix font 404s

### DIFF
--- a/app/styles/cf-base.less
+++ b/app/styles/cf-base.less
@@ -1,0 +1,804 @@
+/* ==========================================================================
+   Capital Framework
+   Base styles
+   ========================================================================== */
+
+// @import (less) "licensed-fonts.css";
+
+
+/* topdoc
+  name: Webfonts
+  family: cf-core
+  patterns:
+    - name: Licensed webfonts
+      notes:
+        - "Avenir Next is included via the licensed-fonts.css file.
+          This file contains absolute links to our paid font service.
+          Fonts included this way will only work on CFPB-registered domains."
+        - "Note that when using Avenir Regular we automatically fix faux italic
+          and bold issues by overriding i, em, b, and strong tags to use the
+          appropriate fonts."
+    - name: Webfont mixins
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+      notes:
+        - "Use these mixins to easily add the Avenir Next font family to your
+          elements."
+        - "To avoid faux bold and italics in Avenir Next, you must use the font
+          family name for that particular style. So when defining an italic or
+          bold style in Avenir Next you need to use the Avenir Next Italic font
+          family. Use the mixins when setting bold or italic text as they also
+          set the appropriate font-weight and font-style."
+        - "These mixins also add the appropriate .lt-ie9 overrides.
+          .lt-ie9 overrides are necessary to override font-style and font-weight
+          each time the webfont is used. These overrides are built into the webfont
+          mixins so you get them automatically. Note that this requires you to
+          use conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes."
+  tags:
+    - cf-core
+*/
+
+.webfont-regular() {
+    font-family: "AvenirNextLTW01-Regular", Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+
+    & em,
+    & i {
+        .webfont-italic();
+    }
+
+    & strong,
+    & b {
+        .webfont-demi();
+    }
+}
+
+.webfont-italic() {
+    font-family: "AvenirNextLTW01-Italic", Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+    .lt-ie9 & {
+        font-style: normal !important;
+    }
+}
+
+.webfont-medium() {
+    font-family: "AvenirNextLTW01-Medium", Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    .lt-ie9 & {
+        font-weight: normal !important;
+    }
+}
+
+.webfont-demi() {
+    font-family: "AvenirNextLTW01-Demi", Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    .lt-ie9 & {
+        font-weight: normal !important;
+    }
+}
+
+
+/* topdoc
+  name: Type hierarchy
+  family: cf-core
+  patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+      notes:
+        - Responsive header. At mobile sizes, displays as h2.
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+      notes:
+        - Responsive header. At mobile sizes, displays as h3.
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+      notes:
+        - Responsive header. At mobile sizes, displays as h4.
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Super header
+      markup: |
+        <h1 class="superheader">Example super heading</h1>
+        <p class="superheader">Example super heading</p>
+  tags:
+    - cf-core
+*/
+
+body {
+    color: @text;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: unit(@base-font-size-px / 16 * 100, %);
+    line-height: @base-line-height;
+}
+
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3 {
+    .webfont-regular();
+}
+
+h1,
+.h1 {
+    @font-size: 34px;
+    @line-height: 44px;
+
+    margin-top: 0;
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 30px.
+    margin-bottom: unit( 16px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: unit( @line-height / @font-size );
+
+    .respond-to-max(@mobile-max, {
+        .h2();
+    });
+}
+
+h2,
+.h2 {
+    @font-size: 26px;
+    @line-height: 33px;
+
+    margin-top: 0;
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 30px.
+    margin-bottom: unit( 19px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: unit( @line-height / @font-size );
+
+    .respond-to-max(@mobile-max, {
+        .h3();
+    });
+}
+
+h3,
+.h3 {
+    @font-size: 22px;
+    @line-height: 28px;
+
+    margin-top: 0;
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 30px.
+    margin-bottom: unit( 21px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: unit( @line-height / @font-size );
+
+    .respond-to-max(@mobile-max, {
+        .h4();
+    });
+}
+
+h4,
+.h4 {
+    @font-size: 18px;
+
+    margin-top: 0;
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 30px.
+    margin-bottom: unit( 21px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    .webfont-medium();
+    line-height: unit( @base-line-height-px / @font-size );
+}
+
+h5,
+h6,
+.h5,
+.h6 {
+    .webfont-demi();
+
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+h5,
+.h5 {
+    @font-size: 14px;
+
+    margin-top: 0;
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 15px.
+    margin-bottom: unit( 5px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: unit( @base-line-height-px / @font-size );
+}
+
+h6,
+.h6 {
+    @font-size: 12px;
+
+    margin-top: 0;
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 15px.
+    margin-bottom: unit( 5px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: unit( @base-line-height-px / @font-size );
+}
+
+
+.superheader {
+    // For when you want a heading that's bigger than a normal H1
+
+    @font-size: 48px;
+    @line-height: 60px;
+
+    // Spacing in the design manual is based off of the baseline so this margin
+    // number has been eyeballed to be 30px.
+    margin-bottom: unit( 9px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    .webfont-demi();
+    line-height: unit( @line-height / @font-size );
+}
+
+
+/* topdoc
+  name: Margins
+  family: cf-core
+  patterns:
+    - name: Consistent vertical margins
+      notes:
+        - "Assumes that the font size of each of these items remains the default."
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+  tags:
+    - cf-core
+*/
+
+p,
+ul,
+ol,
+dl,
+table,
+figure {
+    margin-top: 0;
+    // Spacing has been eyeballed to be 30px from the baseline.
+    margin-bottom: unit(20px / @base-font-size-px, em);
+}
+
+
+/* topdoc
+  name: Default link
+  notes:
+    - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+      be used in production."
+  family: cf-core
+  patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+  tags:
+    - cf-core
+*/
+
+a {
+    border-width: 0;
+    border-style: dotted;
+    border-color: @link-underline;
+    color: @link-text;
+    text-decoration: none;
+
+    &:visited,
+    &.visited {
+        border-color: @link-underline-visited;
+        color: @link-text-visited;
+    }
+
+    &:hover,
+    &.hover {
+        border-style: solid;
+        border-color: @link-underline-hover;
+        color: @link-text-hover;
+    }
+
+    &:focus,
+    &.focus {
+        border-style: solid;
+        outline: thin dotted;
+    }
+
+    &:active,
+    &.active {
+        border-style: solid;
+        border-color: @link-underline-active;
+        color: @link-text-active;
+    }
+}
+
+
+/* topdoc
+  name: Underlined links
+  family: cf-core
+  patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+        - "We're restricting link borders to links within p, li, and dd so that
+          we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+  tags:
+    - cf-core
+*/
+
+p,
+li,
+dd {
+    // Restrict bottom borders to inline text links ...
+
+    a {
+        border-bottom-width: 1px;
+    }
+}
+
+nav a {
+    // ... unless they're part of a nav list
+    border-bottom-width: 0;
+}
+
+
+/* topdoc
+  name: Lists
+  family: cf-core
+  patterns:
+    - name: Unordered list
+      markup: |
+        <ul>
+            <li>List item</li>
+            <li>List item</li>
+            <li>List item</li>
+        </ul>
+  tags:
+    - cf-core
+*/
+
+ul {
+    list-style: square;
+}
+
+
+/* topdoc
+  name: Tables
+  family: cf-core
+  patterns:
+    - name: Standard table
+      markup: |
+        <table>
+            <thead>
+                <tr>
+                    <th>Column 1 header</th>
+                    <th>Column 2 header</th>
+                    <th>Column 3 header</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th>Row 1 header</th>
+                    <td>Row 1, column 2</td>
+                    <td>Row 1, column 3</td>
+                </tr>
+                <tr>
+                    <th>Row 2 header</th>
+                    <td>Row 2, column 2</td>
+                    <td>Row 2, column 3</td>
+                </tr>
+                <tr>
+                    <th>Row 3 header</th>
+                    <td>Row 3, column 2</td>
+                    <td>Row 3, column 3</td>
+                </tr>
+            </tbody>
+        </table>
+    - name: Compact table
+      markup: |
+        <table class="compact-table">
+            <thead>
+                <tr>
+                    <th>Column 1 header</th>
+                    <th>Column 2 header</th>
+                    <th>Column 3 header</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th>Row 1 header</th>
+                    <td>Row 1, column 2</td>
+                    <td>Row 1, column 3</td>
+                </tr>
+                <tr>
+                    <th>Row 2 header</th>
+                    <td>Row 2, column 2</td>
+                    <td>Row 2, column 3</td>
+                </tr>
+                <tr>
+                    <th>Row 3 header</th>
+                    <td>Row 3, column 2</td>
+                    <td>Row 3, column 3</td>
+                </tr>
+            </tbody>
+        </table>
+      notes:
+        - Reduces cell padding to 10px.
+  tags:
+    - cf-core
+*/
+
+table {
+    .webfont-regular();
+}
+
+th,
+td {
+    padding: unit(12px / @base-font-size-px, em) unit(15px / @base-font-size-px, em);
+    background: @td-bg;
+
+    thead & {
+        color: @thead-text;
+        background: @thead-bg;
+    }
+
+    tbody > tr:nth-child(odd) > & {
+        background: @td-bg-alt;
+    }
+
+    .compact-table & {
+        padding: unit(7px / @base-font-size-px, em) unit(10px / @base-font-size-px, em);
+    }
+}
+
+th {
+    .webfont-demi();
+    text-align: left;
+}
+
+
+/* topdoc
+  name: Block quote
+  family: cf-core
+  patterns:
+    - name: Default block quote
+      markup: |
+        <blockquote cite="link-to-source">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa
+            similique fugit hic eligendi praesentium officiis illum optio iusto
+            commodi eum tempore nisi ad in perferendis enim quo dolores.
+            Reprehenderit similique earum quibusdam possimus vitae esse
+            nesciunt mollitia sed beatae aliquid dolores iure a impedit quam
+            minus eum modi illum ducimus eligendi eveniet labore non sequi
+            voluptate et totam praesentium animi itaque asperiores dolorum
+            sunt laudantium repellat nam commodi. Perspiciatis natus aliquam
+            veniam officiis ducimus voluptatum ut necessitatibus non!
+        </blockquote>
+      notes:
+        - "Use a block quote to quote from an external work. See .pull-quote if
+          you need to highlight an excerpt from the current work."
+        - "It is best practice to document the URL of a quoted work using the
+          cite attribute."
+  tags:
+    - cf-core
+*/
+
+blockquote {
+    // Vertical spacing has been eyeballed to be 30px from the baseline.
+    margin: unit(20px / @base-font-size-px, em);
+
+    @media only all and (min-width: (unit(600px / @base-font-size-px, em))) {
+        margin: unit(28px / @base-font-size-px, em)
+                unit(40px / @base-font-size-px, em);
+    }
+}
+
+
+/* topdoc
+    name: Form labels
+    family: cf-core
+    notes:
+      - "Visit https://github.com/cfpb/cf-forms for advanced form label patterns."
+    patterns:
+    - name: Default label
+      markup: |
+        <label>Form label</label>
+    - name: Label wrapping a radio or checkbox
+      markup: |
+        <label>
+            <input type="radio">
+            Radio label
+        </label>
+        <label>
+            <input type="checkbox">
+            Checkbox label
+        </label>
+    tags:
+    - cf-core
+*/
+
+label {
+    display: block;
+    // 5px is eyeballed to 10px when considering line height.
+    margin-bottom: unit(5px / @base-font-size-px, em);
+    .webfont-regular();
+
+    input[type="radio"],
+    input[type="checkbox"] {
+        margin-right: unit(6px / @base-font-size-px, em);
+    }
+}
+
+
+/* topdoc
+    name: Form elements
+    family: cf-core
+    notes:
+      - "The .focus class is only included for documentation demos and should
+         not be used in production."
+      - "Visit https://github.com/cfpb/cf-forms for advanced form field patterns."
+    patterns:
+    - name: type="text"
+      markup: |
+        <input type="text" value="Lorem ipsum">
+        <input class="focus" type="text" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="text" value="">
+    - name: type="search"
+      markup: |
+        <input type="search" value="Lorem ipsum">
+        <input class="focus" type="search" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="search" value="">
+    - name: type="email"
+      markup: |
+        <input type="email" value="Lorem ipsum">
+        <input class="focus" type="email" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="email" value="">
+    - name: type="url"
+      markup: |
+        <input type="url" value="Lorem ipsum">
+        <input class="focus" type="url" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="url" value="">
+    - name: type="tel"
+      markup: |
+        <input type="tel" value="Lorem ipsum">
+        <input class="focus" type="tel" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="tel" value="">
+    - name: type="number"
+      markup: |
+        <input type="number" value="1000">
+        <input class="focus" type="number" value="1000">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="number" value="">
+    - name: textarea
+      markup: |
+        <textarea>Lorem ipsum</textarea>
+        <textarea class="focus">Lorem ipsum</textarea>
+    - name: multi-select
+      markup: |
+        <select multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+        <select class="focus" multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+    tags:
+    - cf-core
+*/
+
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+    @font-size: 16px;
+
+    display: inline-block;
+    margin: 0;
+    padding: unit(6 / @base-font-size-px, em);
+    font-family: Arial, sans-serif;
+    font-size: unit(@font-size / @base-font-size-px, em);
+    background: @input-bg;
+    border: 1px solid @input-border;
+    border-radius: 0;
+    vertical-align: top;
+    -webkit-appearance: none;
+    -webkit-user-modify: read-write-plaintext-only;
+}
+
+// Overrides extra left padding.
+// http://stackoverflow.com/questions/11127891/how-can-i-get-rid-of-horizontal-padding-or-indent-in-html5-search-inputs-in-webk
+::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+
+// The .focus class is only included for documentation demos and should not
+// be used in production.
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
+textarea:focus,
+textarea.focus,
+select[multiple]:focus,
+select[multiple].focus {
+    border: 1px solid @input-border-focus;
+    outline: 1px solid @input-border-focus;
+    outline-offset: 0;
+    box-shadow: none;
+}
+
+::-webkit-input-placeholder {
+   color: @input-placeholder;
+}
+::-moz-placeholder {
+   color: @input-placeholder;
+}
+:-ms-input-placeholder {
+   color: @input-placeholder;
+}
+
+
+/* topdoc
+  name: Images
+  family: cf-core
+  patterns:
+    - name: max-width
+      markup: |
+            <img src="http://placekitten.com/800/40" alt="">
+      notes:
+        - "Gives all images a default max-width of 100% of their container."
+  tags:
+    - cf-core
+*/
+
+img {
+    max-width: 100%;
+}
+
+
+/* topdoc
+  name: Figure
+  family: cf-core
+  patterns:
+    - name: figure
+      markup: |
+        <figure>
+            <img src="http://placekitten.com/340/320">
+        </figure>
+    - name: figure.figure__bordered
+      markup: |
+        <figure class="figure__bordered">
+            <img src="http://placekitten.com/340/320">
+        </figure>
+  tags:
+    - cf-core
+*/
+
+figure {
+    margin-left: 0;
+    margin-right: 0;
+
+    img {
+        // Removes weird vertical spacing below images.
+        vertical-align: middle;
+    }
+}
+
+.figure__bordered img {
+    border: 1px solid @figure__bordered;
+}
+
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/app/styles/hmda-pilot.less
+++ b/app/styles/hmda-pilot.less
@@ -6,7 +6,12 @@
 @import (less) "../../node_modules/cf-core/src/cf-vars.less";
 @import (less) "../../node_modules/cf-core/src/cf-media-queries.less";
 @import (less) "../../node_modules/cf-core/src/cf-utilities.less";
-@import (less) "../../node_modules/cf-core/src/cf-base.less";
+
+// TODO: Replace with cf-core/src/cf-base.less once the fonts for the Capital
+// Framework are self-hosted.
+// @see https://github.com/cfpb/cf-core/issues/33
+@import (less) "cf-base.less";
+
 @import (less) "../../node_modules/cf-grid/src/cf-grid.less";
 @import (less) "../../node_modules/cf-buttons/src/cf-buttons.less";
 @import (less) "../../node_modules/cf-forms/src/cf-forms.less";


### PR DESCRIPTION
Add our own copy of cf-base to the app so that we can remove the licensed-fonts which were included directly in 7f68932d. This should fix the 404s that a user/tester might see in a browser console.