### PR TITLE
Destroy the localdb instance

### DIFF
--- a/app/scripts/controllers/selectFile.js
+++ b/app/scripts/controllers/selectFile.js
@@ -17,6 +17,7 @@ module.exports = /*@ngInject*/ function ($scope, $location, $q, $timeout, FileMe
     HMDAEngine.clearHmdaJson();
     HMDAEngine.clearErrors();
     HMDAEngine.clearProgress();
+    HMDAEngine.destroyDB();
     $scope.metadata = FileMetadata.clear();
     $scope.wizardSteps = Wizard.initSteps();
 

--- a/app/scripts/controllers/validationSummary.js
+++ b/app/scripts/controllers/validationSummary.js
@@ -11,6 +11,7 @@ module.exports = /*@ngInject*/ function ($scope, $location, FileMetadata, HMDAEn
 
     $scope.fileMetadata = FileMetadata.get();
     $scope.transmittalSheet = HMDAEngine.getHmdaJson().hmdaFile.transmittalSheet;
+    HMDAEngine.destroyDB();
 
     $scope.previous = function () {
         $location.path('/summaryMSA-IRS');

--- a/test/spec/controllers/selectFile.js
+++ b/test/spec/controllers/selectFile.js
@@ -22,7 +22,8 @@ describe('Controller: SelectFileCtrl', function () {
             runSyntactical: function() { return; },
             runValidity: function() { return; },
             getDebug: function() { return false; },
-            setUseLocalDB: function() { }
+            setUseLocalDB: function() { },
+            destroyDB: function() { return; }
         };
 
 
@@ -50,6 +51,8 @@ describe('Controller: SelectFileCtrl', function () {
         FileMetadata = _FileMetadata_;
         HMDAEngine = mockEngine;
 
+        spyOn(HMDAEngine, 'destroyDB');
+
         controller('SelectFileCtrl', {
             $scope: scope,
             $location: location,
@@ -75,6 +78,10 @@ describe('Controller: SelectFileCtrl', function () {
         it('should include an empty errors object', function () {
             expect(scope.errors).toBeDefined();
             expect(scope.errors).toEqual({});
+        });
+
+        it('should call destroyDB', function() {
+            expect(HMDAEngine.destroyDB).toHaveBeenCalled();
         });
     });
 

--- a/test/spec/controllers/validationSummary.js
+++ b/test/spec/controllers/validationSummary.js
@@ -8,8 +8,10 @@ describe('Controller: ValidationSummaryCtrl', function () {
     var scope,
         location,
         mockNgDialog,
+        HMDAEngine,
         mockEngine = {
-            getHmdaJson: function() { return {hmdaFile: { transmittalSheet: {}}}; }
+            getHmdaJson: function() { return {hmdaFile: { transmittalSheet: {}}}; },
+            destroyDB: function() { return; }
         };
 
     beforeEach(angular.mock.module('hmdaPilotApp'));
@@ -29,6 +31,9 @@ describe('Controller: ValidationSummaryCtrl', function () {
             openConfirm: function() { }
         };
         spyOn(mockNgDialog, 'openConfirm').and.returnValue(mockNgDialogPromise);
+
+        HMDAEngine = mockEngine;
+        spyOn(HMDAEngine, 'destroyDB');
 
         $controller('ValidationSummaryCtrl', {
             $scope: scope,
@@ -60,6 +65,11 @@ describe('Controller: ValidationSummaryCtrl', function () {
         it('should include the file transmittalSheet', function() {
             expect(scope.transmittalSheet).toBeDefined();
         });
+
+        it('should call destroyDB', function() {
+            expect(HMDAEngine.destroyDB).toHaveBeenCalled();
+        });
+
     });
 
     describe('previous()', function() {


### PR DESCRIPTION
Destroys the localdb instance on first page (select file) and last page (validation summary) automatically.

for #327 