### PR TITLE
Display a modal to show descriptions for each code

### DIFF
--- a/app/partials/codeDescriptions.html
+++ b/app/partials/codeDescriptions.html
@@ -1,1 +1,9 @@
-<p>CODE DESCRIPTIONS!!!</p>
+<h1>HMDA Edit Values</h1>
+
+<div ng-repeat="(label, values) in ngDialogData">
+    <h2>{{label}}</h2>
+    <dl class="dl-horizontal">
+        <dt ng-repeat-start="(key, value) in values">{{key}}</dt>
+        <dd ng-repeat-end>{{value}}</dd>
+    </dl>
+</div>

--- a/app/partials/codeDescriptions.html
+++ b/app/partials/codeDescriptions.html
@@ -1,0 +1,1 @@
+<p>CODE DESCRIPTIONS!!!</p>

--- a/app/partials/errorDetail.html
+++ b/app/partials/errorDetail.html
@@ -1,13 +1,11 @@
 <pagination>
 
 <div class="detail-header content-l">
-    <div class="content-l_col content-l_col-1-3">
+    <div class="content-l_col content-l_col-2-3">
         <pagination-size></pagination-size>
     </div>
-    <div class="content-l_col content-l_col-1-3">
-        <code-descriptions></code-descriptions>
-    </div>
     <div class="toolbar content-l_col content-l_col-1-3">
+        <code-descriptions></code-descriptions>
         <button class="btn btn__link" hmda-export export="individual" type="{{editType}}" edit-id="{{editId}}" ng-if="error"><span class="cf-icon cf-icon-pdf"></span> Export</button>
     </div>
 </div>

--- a/app/partials/errorDetail.html
+++ b/app/partials/errorDetail.html
@@ -5,7 +5,7 @@
         <pagination-size></pagination-size>
     </div>
     <div class="toolbar content-l_col content-l_col-1-3">
-        <code-descriptions></code-descriptions>
+        <button class="btn btn__link code-descriptions" code-descriptions title="Show List of HMDA Edit Values">HMDA Edit Values</button>
         <button class="btn btn__link" hmda-export export="individual" type="{{editType}}" edit-id="{{editId}}" ng-if="error"><span class="cf-icon cf-icon-pdf"></span> Export</button>
     </div>
 </div>

--- a/app/partials/errorDetail.html
+++ b/app/partials/errorDetail.html
@@ -1,8 +1,11 @@
 <pagination>
 
 <div class="detail-header content-l">
-    <div class="content-l_col content-l_col-2-3">
+    <div class="content-l_col content-l_col-1-3">
         <pagination-size></pagination-size>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <code-descriptions></code-descriptions>
     </div>
     <div class="toolbar content-l_col content-l_col-1-3">
         <button class="btn btn__link" hmda-export export="individual" type="{{editType}}" edit-id="{{editId}}" ng-if="error"><span class="cf-icon cf-icon-pdf"></span> Export</button>

--- a/app/partials/errorDetail.html
+++ b/app/partials/errorDetail.html
@@ -5,7 +5,7 @@
         <pagination-size></pagination-size>
     </div>
     <div class="toolbar content-l_col content-l_col-1-3">
-        <button class="btn btn__link code-descriptions" code-descriptions title="Show List of HMDA Edit Values">HMDA Edit Values</button>
+        <button class="btn btn__link code-descriptions" code-descriptions title="Show List of HMDA Edit Values"><span class="cf-icon cf-icon-help-round"></span> HMDA Edit Values</button>
         <button class="btn btn__link" hmda-export export="individual" type="{{editType}}" edit-id="{{editId}}" ng-if="error"><span class="cf-icon cf-icon-pdf"></span> Export</button>
     </div>
 </div>

--- a/app/scripts/directives/codeDescriptions.js
+++ b/app/scripts/directives/codeDescriptions.js
@@ -9,7 +9,7 @@
 module.exports = /*@ngInject*/ function() {
     return {
         restrict: 'E',
-        template: '<button class="btn btn__link" ng-click="open()">Show List of HMDA Edit Values</button>',
+        template: '<button class="btn btn__link code-descriptions" ng-click="open()" title="Show List of HMDA Edit Values">HMDA Edit Values</button>',
         controller: /*ngInject*/ function($scope, HMDAEngine, ngDialog) {
             $scope.open = function() {
                 var properties = {};

--- a/app/scripts/directives/codeDescriptions.js
+++ b/app/scripts/directives/codeDescriptions.js
@@ -6,29 +6,34 @@
  * @namespace hmdaPilotApp
  * @module {Directive} CodeDescriptions
  */
-module.exports = /*@ngInject*/ function() {
+module.exports = /*@ngInject*/ function(HMDAEngine, ngDialog) {
+    function getPropertyDescriptions() {
+        var properties = {};
+
+        var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
+        angular.forEach(['transmittalSheet', 'loanApplicationRegister'], function(val) {
+            for (var prop in fileSpec[val]) {
+                var property = fileSpec[val][prop];
+                if (property.validation && property.validation.type === 'number' && property.validation.values) {
+                    properties[property.label] = property.validation.values;
+                }
+            }
+        });
+
+        return properties;
+    }
+
+    function link(scope, element) {
+        element.bind('click', function() {
+            ngDialog.open({
+                template: 'partials/codeDescriptions.html',
+                data: getPropertyDescriptions()
+            });
+        });
+    }
+
     return {
-        restrict: 'E',
-        template: '<button class="btn btn__link code-descriptions" ng-click="open()" title="Show List of HMDA Edit Values">HMDA Edit Values</button>',
-        controller: /*ngInject*/ function($scope, HMDAEngine, ngDialog) {
-            $scope.open = function() {
-                var properties = {};
-
-                var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
-                angular.forEach(['transmittalSheet', 'loanApplicationRegister'], function(val) {
-                    for (var prop in fileSpec[val]) {
-                        var property = fileSpec[val][prop];
-                        if (property.validation && property.validation.type === 'number' && property.validation.values) {
-                            properties[property.label] = property.validation.values;
-                        }
-                    }
-                });
-
-                ngDialog.open({
-                    template: 'partials/codeDescriptions.html',
-                    data: properties
-                });
-            };
-        }
+        restrict: 'A',
+        link: link
     };
 };

--- a/app/scripts/directives/codeDescriptions.js
+++ b/app/scripts/directives/codeDescriptions.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name hmdaPilotApp.directive:codeDescriptions
+ * @description
+ * # Display text descriptions of what each numeric code is
+ * Directive for displaying code descriptions
+ */
+module.exports = /*@ngInject*/ function() {
+    return {
+        restrict: 'E',
+        templateUrl: 'partials/codeDescriptions.html',
+        controller: /*ngInject*/ function($scope, HMDAEngine) {
+            var properties = {};
+
+            var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
+            angular.forEach(['transmittalSheet', 'loanApplicationRegister'], function(val) {
+                for (var prop in fileSpec[val]) {
+                    var property = fileSpec[val][prop];
+                    if (property.validation && property.validation.type === 'number' && property.validation.values) {
+                        properties[property.label] = property.validation.values;
+                    }
+                }
+            });
+            console.log(properties);
+        }
+    };
+};

--- a/app/scripts/directives/codeDescriptions.js
+++ b/app/scripts/directives/codeDescriptions.js
@@ -10,7 +10,7 @@
 module.exports = /*@ngInject*/ function() {
     return {
         restrict: 'E',
-        template: '<span class="pointer" ng-click="open()">Show List of HMDA Edit Values</span>',
+        template: '<button class="btn btn__link" ng-click="open()">Show List of HMDA Edit Values</button>',
         controller: /*ngInject*/ function($scope, HMDAEngine, ngDialog) {
             $scope.open = function() {
                 var properties = {};

--- a/app/scripts/directives/codeDescriptions.js
+++ b/app/scripts/directives/codeDescriptions.js
@@ -1,11 +1,10 @@
 'use strict';
 
 /**
- * @ngdoc directive
- * @name hmdaPilotApp.directive:codeDescriptions
- * @description
- * # Display text descriptions of what each numeric code is
- * Directive for displaying code descriptions
+ * Display text descriptions of what each numeric code is
+ *
+ * @namespace hmdaPilotApp
+ * @module {Directive} CodeDescriptions
  */
 module.exports = /*@ngInject*/ function() {
     return {

--- a/app/scripts/directives/codeDescriptions.js
+++ b/app/scripts/directives/codeDescriptions.js
@@ -10,20 +10,26 @@
 module.exports = /*@ngInject*/ function() {
     return {
         restrict: 'E',
-        templateUrl: 'partials/codeDescriptions.html',
-        controller: /*ngInject*/ function($scope, HMDAEngine) {
-            var properties = {};
+        template: '<span class="pointer" ng-click="open()">Show List of HMDA Edit Values</span>',
+        controller: /*ngInject*/ function($scope, HMDAEngine, ngDialog) {
+            $scope.open = function() {
+                var properties = {};
 
-            var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
-            angular.forEach(['transmittalSheet', 'loanApplicationRegister'], function(val) {
-                for (var prop in fileSpec[val]) {
-                    var property = fileSpec[val][prop];
-                    if (property.validation && property.validation.type === 'number' && property.validation.values) {
-                        properties[property.label] = property.validation.values;
+                var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
+                angular.forEach(['transmittalSheet', 'loanApplicationRegister'], function(val) {
+                    for (var prop in fileSpec[val]) {
+                        var property = fileSpec[val][prop];
+                        if (property.validation && property.validation.type === 'number' && property.validation.values) {
+                            properties[property.label] = property.validation.values;
+                        }
                     }
-                }
-            });
-            console.log(properties);
+                });
+
+                ngDialog.open({
+                    template: 'partials/codeDescriptions.html',
+                    data: properties
+                });
+            };
         }
     };
 };

--- a/app/scripts/directives/index.js
+++ b/app/scripts/directives/index.js
@@ -14,3 +14,4 @@ app.directive('paginationSize',   require('./paginationSize'));
 app.directive('paginationNav',   require('./paginationNav'));
 app.directive('pagination',   require('./pagination'));
 app.directive('hmdaExport',   require('./hmdaExport'));
+app.directive('codeDescriptions',   require('./codeDescriptions'));

--- a/app/styles/hmda-pilot.less
+++ b/app/styles/hmda-pilot.less
@@ -477,7 +477,3 @@ div.page-size {
         width: auto;
     }
 }
-
-.pointer {
-    cursor: pointer;
-}

--- a/app/styles/hmda-pilot.less
+++ b/app/styles/hmda-pilot.less
@@ -477,3 +477,7 @@ div.page-size {
         width: auto;
     }
 }
+
+.pointer {
+    cursor: pointer;
+}

--- a/app/styles/hmda-pilot.less
+++ b/app/styles/hmda-pilot.less
@@ -373,6 +373,10 @@ table.row-hover {
     .detail-header & {
         margin-top: 0;
     }
+
+    .code-descriptions {
+        margin-right: 1.5em;
+    }
 }
 
 // Pagination

--- a/app/views/errorDetail.html
+++ b/app/views/errorDetail.html
@@ -5,6 +5,8 @@
 <p class="instructions" ng-if="['syntactical', 'validity', 'macro'].indexOf(editType) !== -1">Please review and correct all errors listed below <em>{{editError.errors.length | entries}}</em> in your system of record. Once corrected, re-select the updated file to validate the data.</p>
 <p class="instructions" ng-if="editType === 'quality'">Please review all of the data listed below. You must review the entire list <em>{{editError.errors.length | entries}}</em> and verify that all of the data is correct before proceeding. If any of the data is incorrect, please correct the errors in your system of record and revalidate the file.</p>
 
+<code-descriptions></code-descriptions>
+
 <error-detail type="{{editType}}" error="editError" edit-id="{{selectedEditId}}"></error-detail>
 
 <div class="form-buttons" ng-if="['syntactical', 'validity'].indexOf(editType) !== -1">

--- a/app/views/errorDetail.html
+++ b/app/views/errorDetail.html
@@ -5,8 +5,6 @@
 <p class="instructions" ng-if="['syntactical', 'validity', 'macro'].indexOf(editType) !== -1">Please review and correct all errors listed below <em>{{editError.errors.length | entries}}</em> in your system of record. Once corrected, re-select the updated file to validate the data.</p>
 <p class="instructions" ng-if="editType === 'quality'">Please review all of the data listed below. You must review the entire list <em>{{editError.errors.length | entries}}</em> and verify that all of the data is correct before proceeding. If any of the data is incorrect, please correct the errors in your system of record and revalidate the file.</p>
 
-<code-descriptions></code-descriptions>
-
 <error-detail type="{{editType}}" error="editError" edit-id="{{selectedEditId}}"></error-detail>
 
 <div class="form-buttons" ng-if="['syntactical', 'validity'].indexOf(editType) !== -1">

--- a/test/spec/directives/codeDescriptions.js
+++ b/test/spec/directives/codeDescriptions.js
@@ -12,6 +12,8 @@ describe('Directive: Code Descriptions', function () {
     var element,
         scope,
         $el,
+        HMDAEngine,
+        ngDialog,
         mockFileSpec = {
             transmittalSheet: {
                 agencyCode: {
@@ -34,7 +36,7 @@ describe('Directive: Code Descriptions', function () {
                     label: 'Loan Type',
                     validation: {
                         type: 'number',
-                        'values': {
+                        values: {
                             '1': 'Conventional (any loan other than FHA, VA, FSA, or RHS loans)',
                             '2': 'FHA-insured (Federal Housing Administration)',
                             '3': 'VA-guaranteed (Veterans Administration)',
@@ -46,13 +48,9 @@ describe('Directive: Code Descriptions', function () {
         };
 
     beforeEach(inject(function(_ngDialog_) {
-        spyOn(_ngDialog_, 'open');
-    }));
-
-    beforeEach(angular.mock.module(function($provide) {
-        $provide.value('HMDAEngine', {
-            getFileSpec: function() { return mockFileSpec; }
-        });
+        HMDAEngine = { getFileSpec: function() { return mockFileSpec; } };
+        ngDialog = _ngDialog_;
+        spyOn(ngDialog, 'open');
     }));
 
     beforeEach(inject(function($templateCache) {

--- a/test/spec/directives/codeDescriptions.js
+++ b/test/spec/directives/codeDescriptions.js
@@ -85,17 +85,15 @@ describe('Directive: Code Descriptions', function () {
 
     beforeEach(inject(function ($rootScope, $compile) {
         scope = $rootScope.$new();
-        element = angular.element('<code-descriptions></code-descriptions>');
+        element = angular.element('<button code-descriptions></button>');
         element = $compile(element)(scope);
         scope.$digest();
         $el = jQuery(element);
     }));
 
-    describe('template', function() {
-        it('should display a button to open the modal', function() {
-            var $btn = $el.find('button');
-            expect($btn.length).toBeGreaterThan(0);
-            $btn.click();
+    describe('when applied to an element', function() {
+        it('should open a modal when clicked', function() {
+            $el.click();
             expect(ngDialog.open).toHaveBeenCalled();
         });
     });

--- a/test/spec/directives/codeDescriptions.js
+++ b/test/spec/directives/codeDescriptions.js
@@ -16,6 +16,22 @@ describe('Directive: Code Descriptions', function () {
         ngDialog,
         mockFileSpec = {
             transmittalSheet: {
+                recordID: {
+                    label: 'Record Identifier',
+                    validation: {
+                        type: 'number',
+                        canBeBlank: false,
+                        canBeNA: false
+                    }
+                },
+                respondentID: {
+                    label: 'Respondent-ID',
+                    validation: {
+                        type: 'string',
+                        canBeBlank: false,
+                        canBeNA: false
+                    }
+                },
                 agencyCode: {
                     label: 'Agency Code',
                     validation: {
@@ -47,8 +63,10 @@ describe('Directive: Code Descriptions', function () {
             }
         };
 
-    beforeEach(inject(function(_ngDialog_) {
-        HMDAEngine = { getFileSpec: function() { return mockFileSpec; } };
+    beforeEach(inject(function(_HMDAEngine_, _ngDialog_) {
+        HMDAEngine = _HMDAEngine_;
+        HMDAEngine.getFileSpec = function() { return mockFileSpec; };
+        HMDAEngine.getRuleYear = function() { return '2013'; };
         ngDialog = _ngDialog_;
         spyOn(ngDialog, 'open');
     }));
@@ -73,8 +91,18 @@ describe('Directive: Code Descriptions', function () {
         $el = jQuery(element);
     }));
 
+    describe('template', function() {
+        it('should display a clickable span', function() {
+            var $span = $el.find('span');
+            expect($span.hasClass('pointer')).toBeTruthy();
+            $span.click();
+            expect(ngDialog.open).toHaveBeenCalled();
+        });
+    });
+
     describe('open', function() {
-        it('should display a definition list', function () {
+        it('should display a definition list', function() {
+            jQuery('span', element).click();
             expect($el.find('dl')).toBeDefined();
         });
     });

--- a/test/spec/directives/codeDescriptions.js
+++ b/test/spec/directives/codeDescriptions.js
@@ -1,0 +1,83 @@
+/*global jQuery:true*/
+
+'use strict';
+
+require('angular');
+require('angular-mocks');
+
+describe('Directive: Code Descriptions', function () {
+
+    beforeEach(angular.mock.module('hmdaPilotApp'));
+
+    var element,
+        scope,
+        $el,
+        mockFileSpec = {
+            transmittalSheet: {
+                agencyCode: {
+                    label: 'Agency Code',
+                    validation: {
+                        type: 'number',
+                        values: {
+                            '1': 'OCC',
+                            '2': 'FRS',
+                            '3': 'FDIC',
+                            '5': 'NCUA',
+                            '7': 'HUD',
+                            '9': 'CFPB'
+                        }
+                    }
+                }
+            },
+            loanApplicationRegister: {
+                loanType: {
+                    label: 'Loan Type',
+                    validation: {
+                        type: 'number',
+                        'values': {
+                            '1': 'Conventional (any loan other than FHA, VA, FSA, or RHS loans)',
+                            '2': 'FHA-insured (Federal Housing Administration)',
+                            '3': 'VA-guaranteed (Veterans Administration)',
+                            '4': 'FSA/RHS (Farm Service Agency or Rural Housing Service)'
+                         }
+                     }
+                }
+            }
+        };
+
+    beforeEach(inject(function(_ngDialog_) {
+        spyOn(_ngDialog_, 'open');
+    }));
+
+    beforeEach(angular.mock.module(function($provide) {
+        $provide.value('HMDAEngine', {
+            getFileSpec: function() { return mockFileSpec; }
+        });
+    }));
+
+    beforeEach(inject(function($templateCache) {
+        var directiveTemplate = null;
+        var templateId = 'partials/codeDescriptions.html';
+        var req = new XMLHttpRequest();
+        req.onload = function() {
+            directiveTemplate = this.responseText;
+        };
+        req.open('get', '/base/app/'+templateId, false);
+        req.send();
+        $templateCache.put(templateId, directiveTemplate);
+    }));
+
+    beforeEach(inject(function ($rootScope, $compile) {
+        scope = $rootScope.$new();
+        element = angular.element('<code-descriptions></code-descriptions>');
+        element = $compile(element)(scope);
+        scope.$digest();
+        $el = jQuery(element);
+    }));
+
+    describe('open', function() {
+        it('should display a definition list', function () {
+            expect($el.find('dl')).toBeDefined();
+        });
+    });
+});

--- a/test/spec/directives/codeDescriptions.js
+++ b/test/spec/directives/codeDescriptions.js
@@ -94,16 +94,9 @@ describe('Directive: Code Descriptions', function () {
     describe('template', function() {
         it('should display a button to open the modal', function() {
             var $btn = $el.find('button');
-            expect($btn).not.toBeNull();
+            expect($btn.length).toBeGreaterThan(0);
             $btn.click();
             expect(ngDialog.open).toHaveBeenCalled();
-        });
-    });
-
-    describe('open', function() {
-        it('should display a definition list', function() {
-            $el.find('button').click();
-            expect($el.find('dl')).toBeDefined();
         });
     });
 });

--- a/test/spec/directives/codeDescriptions.js
+++ b/test/spec/directives/codeDescriptions.js
@@ -92,17 +92,17 @@ describe('Directive: Code Descriptions', function () {
     }));
 
     describe('template', function() {
-        it('should display a clickable span', function() {
-            var $span = $el.find('span');
-            expect($span.hasClass('pointer')).toBeTruthy();
-            $span.click();
+        it('should display a button to open the modal', function() {
+            var $btn = $el.find('button');
+            expect($btn).not.toBeNull();
+            $btn.click();
             expect(ngDialog.open).toHaveBeenCalled();
         });
     });
 
     describe('open', function() {
         it('should display a definition list', function() {
-            jQuery('span', element).click();
+            $el.find('button').click();
             expect($el.find('dl')).toBeDefined();
         });
     });


### PR DESCRIPTION
For #316.

Adds a link to show a modal with code descriptions to the error detail page.

This aggregates all of the values and labels from the current year's file spec. Note that this produces some possibly 'duplicate' entries, e.g. 'Applicant Race: 2' and 'Applicant Race: 3'. 'Applicant Race: 1' has different values from the other four fields because it includes options like 'Not Applicable'.

> Applicant Race: 1
1 American Indian or Alaska Native
2 Asian
3 Black or African American
4 Native Hawaiian or Other Pacific Islander
5 White
6 Information not provided by applicant in mail, Internet, or telephone application
7 Not applicable

> Applicant Race: 2
1 American Indian or Alaska Native
2 Asian
3 Black or African American
4 Native Hawaiian or Other Pacific Islander
5 White

> Applicant Race: 3
1 American Indian or Alaska Native
2 Asian
3 Black or African American
4 Native Hawaiian or Other Pacific Islander
5 White
