### PR TITLE
Allow referencing transmittal sheet properties using dot notation

### DIFF
--- a/app/scripts/modules/hmdaFilters.js
+++ b/app/scripts/modules/hmdaFilters.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function getFileSpecSection(scope, lineNumber) {
+function getFileSpecSection(scope, lineNumber, property) {
     var scopes = {
         lar: 'loanApplicationRegister',
         ts: 'transmittalSheet'
@@ -12,8 +12,18 @@ function getFileSpecSection(scope, lineNumber) {
         if (lineNumber === '1') {
             scope = 'ts';
         }
+
+        // Allow referencing TS properties for lineNumbers != 1 (LARs)
+        // using dot notation
+        if (property && property.indexOf('transmittalSheet') !== -1) {
+            scope = 'ts';
+            property = property.replace(/transmittalSheet\./i, '');
+        }
     }
-    return scopes[scope];
+    return {
+        scope: scopes[scope],
+        property: property
+    };
 }
 
 /**
@@ -31,11 +41,11 @@ angular.module('hmdaFilters', [])
      *                            transmittalSheet
      * @return {string}           Human-readable label
      */
-    .filter('hmdaLabel', ['HMDAEngine', 'FileMetadata', function(HMDAEngine, FileMetadata) {
+    .filter('hmdaLabel', ['HMDAEngine', function(HMDAEngine) {
         return function(input, scope) {
-            var section = getFileSpecSection(scope, input.lineNumber);
-            var fileSpec = HMDAEngine.getFileSpec(FileMetadata.get().activityYear);
-            var property = fileSpec[section][input.property];
+            var scopeAndProp = getFileSpecSection(scope, input.lineNumber, input.property);
+            var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
+            var property = fileSpec[scopeAndProp.scope][scopeAndProp.property];
             if (property !== undefined && property.hasOwnProperty('label')) {
                 return property.label;
             }
@@ -76,9 +86,9 @@ angular.module('hmdaFilters', [])
 
         return function(value, scope, property) {
             if (value !== 'NA') {
-                var section = getFileSpecSection(scope, value.lineNumber);
+                var scopeAndProp = getFileSpecSection(scope, value.lineNumber, property);
                 var fileSpec = HMDAEngine.getFileSpec(HMDAEngine.getRuleYear());
-                var propSpec = fileSpec[section][property];
+                var propSpec = fileSpec[scopeAndProp.scope][scopeAndProp.property];
 
                 if (propSpec !== undefined && propSpec.hasOwnProperty('validation')) {
                     var propVal = propSpec.validation;

--- a/test/spec/modules/hmdaFilters.js
+++ b/test/spec/modules/hmdaFilters.js
@@ -23,15 +23,6 @@ describe('Filters: hmdaFilters', function() {
                     }
                 }
             },
-            mockMetadata = {
-                filename: 'test.dat',
-                activityYear: '2015',
-                respondentID: '1234567890',
-                totalLineEntries: '42'
-            },
-            mockFileMetadataService = {
-                get: function() { return mockMetadata; }
-            },
             mockFileSpec = {
                 transmittalSheet: {
                     activityYear: {
@@ -52,10 +43,10 @@ describe('Filters: hmdaFilters', function() {
             };
 
         beforeEach(angular.mock.module(function($provide) {
-            $provide.value('FileMetadata', mockFileMetadataService);
             $provide.value('HMDAEngine', {
                 getFileSpec: function() { return mockFileSpec; },
-                getHmdaJson: function() { return mockHmdaFile; }
+                getHmdaJson: function() { return mockHmdaFile; },
+                getRuleYear: function() { return '2015'; }
             });
         }));
 
@@ -73,6 +64,10 @@ describe('Filters: hmdaFilters', function() {
 
         it('should return the length of the input object\'s keys for hmda and line != 1', angular.mock.inject(function(hmdaLabelFilter) {
             expect(hmdaLabelFilter({property:'recordID', lineNumber:'x'}, 'hmda')).toBe('Record Identifier');
+        }));
+
+        it('should return the length of the input object\'s keys for hmda and dot notation ts property', angular.mock.inject(function(hmdaLabelFilter) {
+            expect(hmdaLabelFilter({property:'transmittalSheet.activityYear', lineNumber:'2'}, 'hmda')).toBe('Activity Year');
         }));
 
         it('should return the property as label when property can\'t be found and line 1', angular.mock.inject(function(hmdaLabelFilter) {


### PR DESCRIPTION
This is the second half of the fix for #368. This is a situation where the scope is `hmda`, but the properties are not referencing one of either `lar` or `ts` but both. Since `lar` is the primary scope for the properties, allow referencing those `ts` properties using dot notation.