### PR TITLE
Make sure markdown task runs before other dist tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -622,6 +622,7 @@ module.exports = function (grunt) {
       'jscs',
       'jshint',
       'replace:' + env,
+      'markdown:help',
       'browserify:dist',
       'ngAnnotate:dist',
       'less:dist',
@@ -633,8 +634,7 @@ module.exports = function (grunt) {
       'uglify',
       'filerev',
       'usemin',
-      'htmlmin',
-      'markdown:help'
+      'htmlmin'
     ]);
   });
 


### PR DESCRIPTION
Now that we've removed pre-generated versions of the markdown files from the repo, we need to make sure they get generated before other `dist` tasks run.