### PR TITLE
Add browser requirements for the pilot

### DIFF
--- a/COMMON_QUESTIONS.md
+++ b/COMMON_QUESTIONS.md
@@ -4,6 +4,25 @@
 
  This HMDA Pilot is part of the [Consumer Financial Protection Bureau's](http://consumerfinance.gov/) (CFPB) work to improve the Home Mortgage Disclosure Act (HMDA) electronic reporting process for financial institutions. The CFPB is testing whether the HMDA Pilot application makes it easier for HMDA filers to review, validate and correct HMDA file submission edits. This site does not in any way alter or substitute your obligations for submitting data under HMDA. See [ffiec.gov/hmda](http://www.ffiec.gov/hmda/) for more details about your legal obligations.
 
+1. **What are the requirements for using the HMDA Pilot?**
+
+  The HMDA Pilot requires that you process your data using one of the following browsers:
+
+  * Firefox 33+
+  * Google Chrome 36+
+  * Internet Explorer 10 or 11
+
+  In addition, because the HMDA Pilot is an application running within your browser, the following guidelines are suggested based on the number of LARs you are trying to validate.
+
+  | Number of LARs | Use Validator Performance Option? |
+  |----------------|-----------------------------------|
+  | Less than 1000 | -                                 |
+  | 1000 to 50K    | Recommended                       |
+  | 50K to 500K    | Required                          |
+  | More than 500K | See below                         |
+
+  If you are attempting to validate more than 500K LARs, validating via the HMDA Pilot may not complete depending on the the processor and memory available to your browser. 
+
 1. **Where can I find the file format for the HMDA Dataset I would like to validate with the HMDA Pilot tool?**
 
  The HMDA Pilot tool will accept 2013 or 2014 [properly formatted HMDA .DAT files](http://www.ffiec.gov/hmda/fileformats.htm).


### PR DESCRIPTION
For #350, added an initial set of browser reqs to the Common Questions based on the timings done by @doelleri's in his [timing doc](https://docs.google.com/a/cfpb.gov/spreadsheets/d/1i567yXMLFjbZX54js-z5t91HFLlNEeymzfw9UmKmo6Q/edit?usp=sharing). Given how long processing takes in the current desktop application, its safe to assume that a user will most likely run out of resources, before they get tired of waiting for the HMDA Pilot to complete the validation of their file. 

I chose to set the dividers using the breakout of [LARs per 2012 filers](https://github.com/cfpb/hmda-pilot/issues/350#issuecomment-94012184), and whether they could complete syntactical and validity edits in 15mins or less. After reviewing the data, the determining factor on whether the user can complete the syn/val validations in the given period of time is if they have opted-in to using the census data locally. After comparing the # of 2012 filers and the timings, the browser reqs below are being proposed. 

One thing to keep in mind is that the requirements, aside from browser, are pretty flexible. These instructions could get REALLY lengthy and require that the reader take several things into consideration. What is below is a very simple "rule of thumb" that should work for most users and still cover over 99.8% of filers.

For review by @ericspry, @debseidner and @lesgou. 

/cc @pkaplan, @doelleri and @LinuxBozo 