### PR TITLE
Run edit check tests only

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -544,6 +544,11 @@ module.exports = function (grunt) {
                 configFile: 'test/functional/conf.js'
             }
         },
+        editChecks: {
+            options: {
+                configFile: 'test/functional/editCheck-conf.js'
+            }
+        },
         sauceLabs: {
             options: {
                 configFile: 'test/functional/sauce-conf.js'

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ $ export SAUCE_ACCESS_KEY=<Accesskey>
 $ grunt functional:sauceLabs
 ```
 
+### Running the edit check functional tests
+
+The functional testing framework has also been setup to test edit checks themselves by testing to make sure that known errors appear with a given DAT files. To run these tests use the following
+
+```shell
+$ grunt functional:editChecks
+```
+
+This will run the edit check tests locally against the DEV environment in Google Chrome.
+
 ## Getting involved
 
 For details on how to get involved, please first read our [CONTRIBUTING](CONTRIBUTING.md) guidelines.

--- a/test/functional/conf.js
+++ b/test/functional/conf.js
@@ -19,7 +19,7 @@ exports.config = {
     framework: 'cucumber',
     cucumberOpts: {
         require: 'cucumber/step_definitions/*.js',
-        tags: ['~@wip', '~@ignore'],
+        tags: ['~@wip', '~@ignore', '~@editCheck'],
         format: 'progress'
     },
 

--- a/test/functional/editCheck-conf.js
+++ b/test/functional/editCheck-conf.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var browserWidth = 1280,
+    browserHeight = 1024;
+
+exports.config = {
+
+    baseUrl: 'http://dev.hmda-pilot.devis.com/',
+
+    specs: ['cucumber/*.feature'],
+
+    allScriptsTimeout: 30000,
+    getPageTimeout: 30000,
+
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    framework: 'cucumber',
+    cucumberOpts: {
+        require: 'cucumber/step_definitions/*.js',
+        tags: ['~@wip', '~@ignore', '@editCheck'],
+        format: 'progress'
+    },
+
+    onPrepare: function() {
+        browser.driver.manage().window().setSize(browserWidth, browserHeight);
+    }
+};

--- a/test/functional/sauce-conf.js
+++ b/test/functional/sauce-conf.js
@@ -52,7 +52,7 @@ exports.config = {
     framework: 'cucumber',
     cucumberOpts: {
         require: 'cucumber/step_definitions/*.js',
-        tags: ['~@wip', '~@ignore'],
+        tags: ['~@wip', '~@ignore', '~@editCheck'],
         format: 'progress'
     },
 


### PR DESCRIPTION
Add a grunt task and config to run the editCheck specific functional tests. Also removed the editCheck specific tests from running as part of the default functional tests.

/cc @henrygrover and @porterbot 