### PR TITLE
Init wizard service vars instead of leaving them undefined

### DIFF
--- a/app/scripts/services/wizard.js
+++ b/app/scripts/services/wizard.js
@@ -8,8 +8,8 @@
  */
 module.exports = /*@ngInject*/ function(StepFactory) {
 
-    var steps,
-        currentStepIdx;
+    var steps = [],
+        currentStepIdx = 0;
 
     /**
      * Initialize the steps used in the wizard


### PR DESCRIPTION
This should fix #389 in IE11. Cause seems related to a timing issue where the variables are declared, but uninitialized when first accessed, therefore equal `undefined` as shown in the console.